### PR TITLE
fix: Packaging bug

### DIFF
--- a/dbt/adapters/scope/__init__.py
+++ b/dbt/adapters/scope/__init__.py
@@ -5,9 +5,10 @@ from dbt.adapters.scope.connections import ScopeConnectionManager  # noqa: F401
 from dbt.adapters.scope.credentials import ScopeCredentials
 from dbt.adapters.scope.impl import ScopeAdapter
 from dbt.adapters.scope.relation import ScopeRelation  # noqa: F401
+from dbt.include import scope as include_scope
 
 Plugin = AdapterPlugin(
     adapter=ScopeAdapter,
     credentials=ScopeCredentials,
-    include_path="dbt/include/scope",
+    include_path=include_scope.PACKAGE_PATH,
 )

--- a/dbt/include/scope/__init__.py
+++ b/dbt/include/scope/__init__.py
@@ -1,0 +1,3 @@
+import os
+
+PACKAGE_PATH = os.path.dirname(__file__)


### PR DESCRIPTION
> [!NOTE]
> Thank you for making change! Please consider filling this template for your pull request to improve quality of checkin message.

> [!TIP]
> This repo uses [Conventional Commit conventions](https://www.conventionalcommits.org/en/v1.0.0/) - please try to rename your PR headline to match it.

# Why this change is needed

The adapter packaging was not putting the necessary things into path, failing with:

```bash
Could not find profile named 'dbt_scope'
```

# How

Package things up similar to https://github.com/[microsoft/dbt-fabricspark](https://github.com/microsoft/dbt-fabricspark)

# Test

GCI and also tested in a consumer project.