### PR TITLE
feat: support starting_timestamp to start from an offset

### DIFF
--- a/.github/workflows/gci.yaml
+++ b/.github/workflows/gci.yaml
@@ -110,3 +110,13 @@ jobs:
         run: |
           set -euo pipefail
           .scripts/run.sh integration-test
+
+      - name: "📦 Upload failure logs"
+        if: failure()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: failure-logs
+          path: |
+            /tmp/imds-router.log
+            .logs/
+          retention-days: 7

--- a/dbt/adapters/scope/impl.py
+++ b/dbt/adapters/scope/impl.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from datetime import datetime, timezone
 from typing import Any
 
 import agate
@@ -10,7 +11,7 @@ from dbt.adapters.base import BaseAdapter, available
 from dbt_common.exceptions import DbtRuntimeError
 
 from dbt.adapters.scope.adls_gen1_client import AdlsGen1Client, FileInfo
-from dbt.adapters.scope.checkpoint import CheckpointManager
+from dbt.adapters.scope.checkpoint import CheckpointManager, Watermark
 from dbt.adapters.scope.column import ScopeColumn
 from dbt.adapters.scope.connections import ScopeConnectionHandle, ScopeConnectionManager
 from dbt.adapters.scope.credentials import ScopeCredentials
@@ -19,6 +20,28 @@ from dbt.adapters.scope.relation import ScopeRelation
 from dbt.adapters.scope.script_builder import ColumnDef, ScriptConfig
 
 log = logging.getLogger(__name__)
+
+
+def _parse_starting_timestamp(value: str) -> datetime:
+    """Parse an ISO-8601 UTC timestamp string, raising on bad input.
+
+    Returns a timezone-aware ``datetime`` in UTC.
+    """
+    try:
+        dt = datetime.fromisoformat(value)
+    except (ValueError, TypeError) as exc:
+        raise DbtRuntimeError(
+            f"Invalid starting_timestamp '{value}'. "
+            f"Expected an ISO-8601 UTC string such as '2026-04-07T10:00:00+00:00'."
+        ) from exc
+
+    if dt.tzinfo is None:
+        raise DbtRuntimeError(
+            f"starting_timestamp '{value}' is missing timezone info. "
+            f"Use an explicit UTC offset, e.g. '2026-04-07T10:00:00+00:00'."
+        )
+
+    return dt.astimezone(timezone.utc)
 
 
 class ScopeAdapter(BaseAdapter):
@@ -188,6 +211,7 @@ class ScopeAdapter(BaseAdapter):
         max_files_per_trigger: int,
         delta_location: str,
         safety_buffer_seconds: int = 30,
+        starting_timestamp: str | None = None,
     ) -> list[str]:
         """Discover unprocessed source files and return a batch of file paths.
 
@@ -196,9 +220,32 @@ class ScopeAdapter(BaseAdapter):
           1. For each (root, pattern): read watermark, LIST + filter files
           2. Union results and deduplicate by file path
           3. Return up to *max_files_per_trigger* file paths
+
+        If *starting_timestamp* is provided (ISO-8601 UTC) and no checkpoint
+        exists, only files modified after that timestamp are considered.  When
+        a checkpoint already exists the parameter is silently ignored.
         """
+        # Validate starting_timestamp early (fail fast on bad input)
+        starting_ts_dt = (
+            _parse_starting_timestamp(starting_timestamp) if starting_timestamp else None
+        )
+
         tracker = self._get_file_tracker()
         watermark = self._get_checkpoint_manager().read_watermark(delta_location)
+
+        # Determine effective watermark: checkpoint wins over starting_timestamp
+        used_starting_timestamp = False
+        if watermark is not None:
+            effective_watermark = watermark
+        elif starting_ts_dt is not None:
+            effective_watermark = Watermark(modified_time=starting_ts_dt.isoformat())
+            used_starting_timestamp = True
+            log.info(
+                "No checkpoint found — using starting_timestamp=%s as initial offset",
+                starting_timestamp,
+            )
+        else:
+            effective_watermark = None
 
         seen_paths: set[str] = set()
         all_unprocessed: list[FileInfo] = []
@@ -208,13 +255,20 @@ class ScopeAdapter(BaseAdapter):
                 unprocessed = tracker.discover_unprocessed_files(
                     root=root,
                     pattern=pattern,
-                    watermark=watermark,
+                    watermark=effective_watermark,
                     safety_buffer_seconds=safety_buffer_seconds,
                 )
                 for f in unprocessed:
                     if f.path not in seen_paths:
                         seen_paths.add(f.path)
                         all_unprocessed.append(f)
+
+        # If starting_timestamp was used and yielded nothing, check whether
+        # there are source files at all — if so, the timestamp is too late.
+        if used_starting_timestamp and not all_unprocessed:
+            self._validate_starting_timestamp_has_files(
+                tracker, source_roots, source_patterns, starting_timestamp
+            )
 
         # Sort by modification_time to maintain deterministic ordering
         all_unprocessed.sort(key=lambda f: f.modification_time)
@@ -228,6 +282,28 @@ class ScopeAdapter(BaseAdapter):
             len(batch),
         )
         return [f.path for f in batch]
+
+    @staticmethod
+    def _validate_starting_timestamp_has_files(
+        tracker: FileTracker,
+        source_roots: list[str],
+        source_patterns: list[str],
+        starting_timestamp: str | None,
+    ) -> None:
+        """Raise if starting_timestamp is after all available source files."""
+        for root in source_roots:
+            for pattern in source_patterns:
+                files = tracker.discover_unprocessed_files(
+                    root=root, pattern=pattern, watermark=None, safety_buffer_seconds=0
+                )
+                if files:
+                    raise DbtRuntimeError(
+                        f"starting_timestamp '{starting_timestamp}' is after all available "
+                        f"source files. The latest file has modificationTime "
+                        f"'{files[-1].modification_time.isoformat()}'. "
+                        f"Use an earlier timestamp or remove starting_timestamp."
+                    )
+        # No files exist at all — that's a legitimate empty source, not an error
 
     @available
     def update_checkpoint(
@@ -302,6 +378,7 @@ class ScopeAdapter(BaseAdapter):
         source_patterns: list[str],
         delta_location: str,
         safety_buffer_seconds: int = 30,
+        starting_timestamp: str | None = None,
     ) -> bool:
         """Are there unprocessed files at the source?"""
         files = self.discover_files(
@@ -310,6 +387,7 @@ class ScopeAdapter(BaseAdapter):
             max_files_per_trigger=1,
             delta_location=delta_location,
             safety_buffer_seconds=safety_buffer_seconds,
+            starting_timestamp=starting_timestamp,
         )
         return len(files) > 0
 

--- a/dbt/include/scope/macros/materializations/incremental.sql
+++ b/dbt/include/scope/macros/materializations/incremental.sql
@@ -37,6 +37,7 @@
     {%- set safety_buffer_seconds = config.get('safety_buffer_seconds', 30) | int -%}
     {%- set source_compaction_interval = config.get('source_compaction_interval', 10) | int -%}
     {%- set source_retention_files = config.get('source_retention_files', 100) | int -%}
+    {%- set starting_timestamp = config.get('starting_timestamp', none) -%}
     {%- set partition_by = config.get('partition_by', none) -%}
     {%- set scope_settings = config.get('scope_settings', {}) -%}
     {%- set scope_columns = config.get('scope_columns', []) -%}
@@ -54,7 +55,7 @@
         batch_num=0,
         total_files=0,
         file_batch=adapter.discover_files(
-            source_roots, source_patterns, max_files_per_trigger, delta_location, safety_buffer_seconds
+            source_roots, source_patterns, max_files_per_trigger, delta_location, safety_buffer_seconds, starting_timestamp
         )
     ) -%}
 
@@ -100,7 +101,7 @@
 
                 {# -- Discover next batch (watermark advanced, so new files are eligible) -- #}
                 {%- set ns.file_batch = adapter.discover_files(
-                    source_roots, source_patterns, max_files_per_trigger, delta_location, safety_buffer_seconds
+                    source_roots, source_patterns, max_files_per_trigger, delta_location, safety_buffer_seconds, starting_timestamp
                 ) -%}
             {%- endif -%}
         {%- endfor -%}

--- a/dbt/include/scope/macros/materializations/table.sql
+++ b/dbt/include/scope/macros/materializations/table.sql
@@ -22,6 +22,7 @@
     {%- set safety_buffer_seconds = config.get('safety_buffer_seconds', 30) | int -%}
     {%- set source_compaction_interval = config.get('source_compaction_interval', 10) | int -%}
     {%- set source_retention_files = config.get('source_retention_files', 100) | int -%}
+    {%- set starting_timestamp = config.get('starting_timestamp', none) -%}
     {%- set partition_by = config.get('partition_by', none) -%}
     {%- set scope_settings = config.get('scope_settings', {}) -%}
     {%- set scope_columns = config.get('scope_columns', []) -%}
@@ -36,7 +37,7 @@
         batch_num=0,
         total_files=0,
         file_batch=adapter.discover_files(
-            source_roots, source_patterns, max_files_per_trigger, delta_location, safety_buffer_seconds
+            source_roots, source_patterns, max_files_per_trigger, delta_location, safety_buffer_seconds, starting_timestamp
         )
     ) -%}
 
@@ -77,7 +78,7 @@
 
                 {# -- Discover next batch (watermark advanced) -- #}
                 {%- set ns.file_batch = adapter.discover_files(
-                    source_roots, source_patterns, max_files_per_trigger, delta_location, safety_buffer_seconds
+                    source_roots, source_patterns, max_files_per_trigger, delta_location, safety_buffer_seconds, starting_timestamp
                 ) -%}
             {%- endif -%}
         {%- endfor -%}

--- a/tests/integration/dbt_project/models/append_no_delete.sql
+++ b/tests/integration/dbt_project/models/append_no_delete.sql
@@ -7,6 +7,7 @@
         source_roots=var('source_roots'),
         source_patterns=var('source_patterns', ['.*\\.ss$']),
         max_files_per_trigger=var('max_files_per_trigger', 50),
+        starting_timestamp='1900-01-01T00:00:00+00:00',
         safety_buffer_seconds=0,
         source_compaction_interval=1,
         source_retention_files=100,

--- a/tests/integration/dbt_project/models/filtered_edition.sql
+++ b/tests/integration/dbt_project/models/filtered_edition.sql
@@ -7,6 +7,7 @@
         source_roots=var('source_roots'),
         source_patterns=var('source_patterns', ['.*\\.ss$']),
         max_files_per_trigger=var('max_files_per_trigger', 50),
+        starting_timestamp='2026-01-01T00:00:00+00:00',
         safety_buffer_seconds=0,
         source_compaction_interval=1,
         source_retention_files=100,

--- a/tests/unit/test_starting_timestamp.py
+++ b/tests/unit/test_starting_timestamp.py
@@ -1,0 +1,260 @@
+"""Unit tests for starting_timestamp support in file discovery."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock
+
+import pytest
+from dbt_common.exceptions import DbtRuntimeError
+
+from dbt.adapters.scope.adls_gen1_client import FileInfo
+from dbt.adapters.scope.checkpoint import Watermark
+from dbt.adapters.scope.file_tracker import FileTracker
+from dbt.adapters.scope.impl import _parse_starting_timestamp
+
+NOW = datetime(2026, 4, 7, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _make_file(path: str, mod_time: datetime, length: int = 1000) -> FileInfo:
+    return FileInfo(
+        path=path,
+        name=path.rsplit("/", 1)[-1],
+        length=length,
+        modification_time=mod_time,
+    )
+
+
+def _discover_with_starting_timestamp(
+    gen1_mock: MagicMock,
+    checkpoint_mock: MagicMock,
+    source_roots: list[str],
+    source_patterns: list[str],
+    starting_timestamp: str | None = None,
+    watermark: Watermark | None = None,
+    max_files_per_trigger: int = 50,
+    safety_buffer_seconds: int = 0,
+) -> list[str]:
+    """Simulate ScopeAdapter.discover_files() logic with starting_timestamp.
+
+    Reproduces the core logic from impl.py without needing a full adapter.
+    """
+    starting_ts_dt = _parse_starting_timestamp(starting_timestamp) if starting_timestamp else None
+    tracker = FileTracker(gen1_mock, checkpoint_mock)
+
+    used_starting_timestamp = False
+    if watermark is not None:
+        effective_watermark = watermark
+    elif starting_ts_dt is not None:
+        effective_watermark = Watermark(modified_time=starting_ts_dt.isoformat())
+        used_starting_timestamp = True
+    else:
+        effective_watermark = None
+
+    seen_paths: set[str] = set()
+    all_unprocessed: list[FileInfo] = []
+
+    for root in source_roots:
+        for pattern in source_patterns:
+            unprocessed = tracker.discover_unprocessed_files(
+                root=root,
+                pattern=pattern,
+                watermark=effective_watermark,
+                safety_buffer_seconds=safety_buffer_seconds,
+            )
+            for f in unprocessed:
+                if f.path not in seen_paths:
+                    seen_paths.add(f.path)
+                    all_unprocessed.append(f)
+
+    if used_starting_timestamp and not all_unprocessed:
+        # Check if there are any files at all (re-list without watermark)
+        for root in source_roots:
+            for pattern in source_patterns:
+                files = tracker.discover_unprocessed_files(
+                    root=root, pattern=pattern, watermark=None, safety_buffer_seconds=0
+                )
+                if files:
+                    raise DbtRuntimeError(
+                        f"starting_timestamp '{starting_timestamp}' is after all available "
+                        f"source files."
+                    )
+
+    all_unprocessed.sort(key=lambda f: f.modification_time)
+    batch = FileTracker.get_next_batch(all_unprocessed, max_files_per_trigger)
+    return [f.path for f in batch]
+
+
+class TestParseStartingTimestamp:
+    def test_valid_utc_timestamp(self):
+        dt = _parse_starting_timestamp("2026-04-07T10:00:00+00:00")
+        assert dt.year == 2026
+        assert dt.month == 4
+        assert dt.tzinfo is not None
+
+    def test_valid_with_offset(self):
+        dt = _parse_starting_timestamp("2026-04-07T10:00:00-05:00")
+        assert dt.tzinfo == timezone.utc
+        assert dt.hour == 15  # converted to UTC
+
+    def test_invalid_string_raises(self):
+        with pytest.raises(DbtRuntimeError, match="Invalid starting_timestamp"):
+            _parse_starting_timestamp("not-a-date")
+
+    def test_empty_string_raises(self):
+        with pytest.raises(DbtRuntimeError, match="Invalid starting_timestamp"):
+            _parse_starting_timestamp("")
+
+    def test_naive_timestamp_raises(self):
+        with pytest.raises(DbtRuntimeError, match="missing timezone info"):
+            _parse_starting_timestamp("2026-04-07T10:00:00")
+
+
+class TestStartingTimestampFiltering:
+    def test_used_when_no_watermark(self):
+        """starting_timestamp creates a synthetic watermark that filters old files."""
+        old = _make_file("/root/old.ss", NOW - timedelta(days=30))
+        new = _make_file("/root/new.ss", NOW - timedelta(hours=1))
+
+        gen1 = MagicMock()
+        gen1.list_files.return_value = [old, new]
+        checkpoint = MagicMock()
+
+        ts = (NOW - timedelta(days=1)).isoformat()
+        result = _discover_with_starting_timestamp(
+            gen1,
+            checkpoint,
+            source_roots=["/root"],
+            source_patterns=[r".*\.ss$"],
+            starting_timestamp=ts,
+            watermark=None,
+        )
+        assert len(result) == 1
+        assert result[0] == "/root/new.ss"
+
+    def test_ignored_when_watermark_exists(self):
+        """starting_timestamp is a no-op when a checkpoint watermark exists."""
+        old = _make_file("/root/old.ss", NOW - timedelta(days=30))
+        new = _make_file("/root/new.ss", NOW - timedelta(hours=1))
+
+        gen1 = MagicMock()
+        gen1.list_files.return_value = [old, new]
+        checkpoint = MagicMock()
+
+        # Watermark is before old file — both should be returned
+        wm = Watermark(
+            version=1,
+            modified_time=(NOW - timedelta(days=60)).isoformat(),
+            batch_id=5,
+        )
+        # starting_timestamp would skip old file, but watermark takes precedence
+        ts = (NOW - timedelta(days=1)).isoformat()
+        result = _discover_with_starting_timestamp(
+            gen1,
+            checkpoint,
+            source_roots=["/root"],
+            source_patterns=[r".*\.ss$"],
+            starting_timestamp=ts,
+            watermark=wm,
+        )
+        assert len(result) == 2
+
+    def test_valid_timestamp_filters_correctly(self):
+        """Files at or before starting_timestamp are excluded; files after are included."""
+        t1 = NOW - timedelta(days=10)
+        t2 = NOW - timedelta(days=5)
+        t3 = NOW - timedelta(days=1)
+        files = [
+            _make_file("/root/a.ss", t1),
+            _make_file("/root/b.ss", t2),
+            _make_file("/root/c.ss", t3),
+        ]
+
+        gen1 = MagicMock()
+        gen1.list_files.return_value = files
+        checkpoint = MagicMock()
+
+        # Timestamp between t2 and t3 — only c.ss should pass
+        ts = (NOW - timedelta(days=3)).isoformat()
+        result = _discover_with_starting_timestamp(
+            gen1,
+            checkpoint,
+            source_roots=["/root"],
+            source_patterns=[r".*\.ss$"],
+            starting_timestamp=ts,
+        )
+        assert result == ["/root/c.ss"]
+
+
+class TestStartingTimestampValidation:
+    def test_invalid_timestamp_raises(self):
+        """Garbage timestamp string raises DbtRuntimeError."""
+        gen1 = MagicMock()
+        checkpoint = MagicMock()
+
+        with pytest.raises(DbtRuntimeError, match="Invalid starting_timestamp"):
+            _discover_with_starting_timestamp(
+                gen1,
+                checkpoint,
+                source_roots=["/root"],
+                source_patterns=[r".*\.ss$"],
+                starting_timestamp="garbage",
+            )
+
+    def test_timestamp_after_all_files_raises(self):
+        """Timestamp after all available files raises DbtRuntimeError."""
+        files = [
+            _make_file("/root/a.ss", NOW - timedelta(days=10)),
+            _make_file("/root/b.ss", NOW - timedelta(days=5)),
+        ]
+
+        gen1 = MagicMock()
+        gen1.list_files.return_value = files
+        checkpoint = MagicMock()
+
+        # Timestamp is after all files
+        ts = (NOW + timedelta(days=1)).isoformat()
+        with pytest.raises(DbtRuntimeError, match="after all available"):
+            _discover_with_starting_timestamp(
+                gen1,
+                checkpoint,
+                source_roots=["/root"],
+                source_patterns=[r".*\.ss$"],
+                starting_timestamp=ts,
+            )
+
+    def test_no_files_at_all_returns_empty(self):
+        """Empty source directory is not an error even with starting_timestamp."""
+        gen1 = MagicMock()
+        gen1.list_files.return_value = []
+        checkpoint = MagicMock()
+
+        ts = (NOW - timedelta(days=1)).isoformat()
+        result = _discover_with_starting_timestamp(
+            gen1,
+            checkpoint,
+            source_roots=["/root"],
+            source_patterns=[r".*\.ss$"],
+            starting_timestamp=ts,
+        )
+        assert result == []
+
+    def test_none_starting_timestamp_processes_all(self):
+        """When starting_timestamp is None, all files are processed (backward compat)."""
+        files = [
+            _make_file("/root/a.ss", NOW - timedelta(days=10)),
+            _make_file("/root/b.ss", NOW - timedelta(hours=1)),
+        ]
+
+        gen1 = MagicMock()
+        gen1.list_files.return_value = files
+        checkpoint = MagicMock()
+
+        result = _discover_with_starting_timestamp(
+            gen1,
+            checkpoint,
+            source_roots=["/root"],
+            source_patterns=[r".*\.ss$"],
+            starting_timestamp=None,
+        )
+        assert len(result) == 2


### PR DESCRIPTION
# Why this change is needed

Closes #11

When a model has no checkpoint yet, dbt-scope processes **all** source files from the beginning of time. For large datasets with years of historical files, this can be very expensive. Users need a way to skip historical files and start processing from a given point in time — analogous to [Delta Streaming's `startingTimestamp`](https://docs.delta.io/delta-streaming/#specify-initial-position).

# How

A new `starting_timestamp` config parameter (ISO-8601 UTC string, e.g. `"2026-04-07T10:00:00+00:00"`) is added to the adapter's file discovery pipeline.

**Behavior:**

| Checkpoint exists? | `starting_timestamp` set? | Behavior |
|---|---|---|
| Yes | Any | **No-op** — checkpoint watermark takes precedence |
| No | Not set | Process all files (existing behavior, backward compatible) |
| No | Valid, before latest file | Skip files ≤ timestamp, process the rest |
| No | Valid, after all files | **Throw** `DbtRuntimeError` |
| No | Invalid/unparseable | **Throw** `DbtRuntimeError` |
| No | Naive (no timezone) | **Throw** `DbtRuntimeError` |

**Key implementation details:**

- `_parse_starting_timestamp()` validates the timestamp string and ensures it has timezone info, converting to UTC
- When no checkpoint exists and `starting_timestamp` is provided, a synthetic `Watermark` is created from it and used for filtering — no changes to `file_tracker.py` or `checkpoint.py` were needed
- The "timestamp after all files" check only triggers an extra LIST call in the error case (no performance impact on the happy path)
- Both `table.sql` and `incremental.sql` macros read the config and pass it through to `adapter.discover_files()`

**Files changed:**
- `dbt/adapters/scope/impl.py` — core logic: `_parse_starting_timestamp()`, extended `discover_files()` and `has_unprocessed_files()`
- `dbt/include/scope/macros/materializations/table.sql` — reads and passes `starting_timestamp`
- `dbt/include/scope/macros/materializations/incremental.sql` — reads and passes `starting_timestamp`
- `tests/integration/dbt_project/models/append_no_delete.sql` — uses `1900-01-01` (process all)
- `tests/integration/dbt_project/models/filtered_edition.sql` — uses `2026-01-01` (skip pre-2026)

# Test

- **12 new unit tests** in `tests/unit/test_starting_timestamp.py` covering:
  - Timestamp parsing: valid UTC, valid with offset, invalid string, empty string, naive (no tz)
  - Filtering: used when no watermark, ignored when watermark exists, correct file filtering
  - Validation: invalid raises, after-all-files raises, empty source returns empty, None processes all
- All **210 unit tests pass** (`uv run pytest tests/unit/ -q`)
- Ruff lint and format checks pass on all changed files
