### PR TITLE
feat: orphan job cancellation, cleanup, and file listing cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,25 @@ my_project:
       priority: 1
 ```
 
+### Profile reference
+
+| Field                     | Default                                    | Description                                                        |
+| ------------------------- | ------------------------------------------ | ------------------------------------------------------------------ |
+| `adla_account`            | —                                          | ADLA account name                                                  |
+| `storage_account`         | —                                          | ADLS Gen2 storage account name (also used as dbt `database`)       |
+| `container`               | —                                          | ADLS Gen2 container (also used as dbt `schema`)                    |
+| `delta_base_path`         | `"delta"`                                  | Base path under the container for Delta tables                     |
+| `adls_gen1_account`       | `""`                                       | ADLS Gen1 account for source file listing                          |
+| `au`                      | `100`                                      | Default ADLA Analytics Units (parallelism) per job                 |
+| `priority`                | `1`                                        | Default ADLA job priority                                          |
+| `poll_interval_seconds`   | `5`                                        | How often (seconds) to poll ADLA for job status                    |
+| `job_timeout_seconds`     | `36000`                                    | Max seconds to wait for a SCOPE job before timing out              |
+| `max_files_per_trigger`   | `50`                                       | Default max files per SCOPE job (overridable per-model)            |
+| `max_bytes_per_trigger`   | `10737418240000` (10 TB)                   | Default max estimated bytes per batch (overridable per-model)      |
+| `http_timeout_seconds`    | `30`                                       | HTTP request timeout for ADLA REST API calls                       |
+| `http_retries`            | `3`                                        | Number of HTTP retries for transient errors (429, 5xx)             |
+| `scope_feature_previews`  | `"EnableDeltaTableDynamicInsert:on"`       | SCOPE feature preview flags (overridable per-model)                |
+
 | dbt concept   | SCOPE concept                                                                   |
 | ------------- | ------------------------------------------------------------------------------- |
 | `database`    | Storage account name                                                            |
@@ -269,20 +288,27 @@ FROM @data
 WHERE edition == "Standard"
 ```
 
-### Incremental config reference
+### Model config reference
 
-| Config                       | Default                  | Description                                                                                                                                                                            |
-| ---------------------------- | ------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `source_roots`               | `[]`                     | List of ADLS Gen1 root paths to list source files from                                                                                                                                 |
-| `source_patterns`            | `[]`                     | List of regexes; the adapter discovers files for each root × pattern combo                                                                                                             |
-| `max_files_per_trigger`      | `50`                     | Max files per SCOPE job. Larger = fewer jobs; smaller = faster feedback                                                                                                                |
-| `max_bytes_per_trigger`      | `10737418240000` (10 TB) | Max estimated bytes per batch. Works alongside `max_files_per_trigger` — whichever limit is hit first stops the batch. Estimates account for SSv5/v6 `.du` sibling folders (see below) |
-| `safety_buffer_seconds`      | `30`                     | Skip files modified within the last N seconds (avoids partial writes)                                                                                                                  |
-| `source_compaction_interval` | `10`                     | Every N batches, write a parquet snapshot of all source history                                                                                                                        |
-| `source_retention_files`     | `100`                    | Max files in `_checkpoint/sources/` — oldest are deleted first                                                                                                                         |
-| `delta_table_columns`        | `[]`                     | Delta table schema (CREATE TABLE). List of `{name, type}` dicts                                                                                                                        |
-| `extract_columns`            | `[]`                     | Source file columns (EXTRACT). List of `{name, type}` dicts                                                                                                                            |
-| `partition_by`               | —                        | Single column name or list of columns                                                                                                                                                  |
+| Config                       | Default                                | Description                                                                                                                                                                            |
+| ---------------------------- | -------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `delta_location`             | `""`                                   | ABFSS path to the Delta table (e.g. `abfss://ctr@acct.dfs.core.windows.net/delta/my_table`)                                                                                           |
+| `source_roots`               | `[]`                                   | List of ADLS Gen1 root paths to list source files from                                                                                                                                 |
+| `source_patterns`            | `['.*\\.ss$']`                         | List of regexes; the adapter discovers files for each root × pattern combo                                                                                                             |
+| `max_files_per_trigger`      | from profile (`50`)                    | Max files per SCOPE job. Larger = fewer jobs; smaller = faster feedback                                                                                                                |
+| `max_bytes_per_trigger`      | from profile (`10737418240000`, 10 TB) | Max estimated bytes per batch. Works alongside `max_files_per_trigger` — whichever limit is hit first stops the batch. Estimates account for SSv5/v6 `.du` sibling folders (see below) |
+| `safety_buffer_seconds`      | `30`                                   | Skip files modified within the last N seconds (avoids partial writes)                                                                                                                  |
+| `source_compaction_interval` | `10`                                   | Every N batches, write a parquet snapshot of all source history                                                                                                                        |
+| `source_retention_files`     | `100`                                  | Max files in `_checkpoint/sources/` — oldest are deleted first                                                                                                                         |
+| `starting_timestamp`         | —                                      | ISO 8601 timestamp (e.g. `2026-01-01T00:00:00+00:00`); only process files modified after this time when no watermark exists                                                            |
+| `delta_table_columns`        | `[]`                                   | Delta table schema (CREATE TABLE). List of `{name, type}` dicts                                                                                                                        |
+| `extract_columns`            | `[]`                                   | Source file columns (EXTRACT). List of `{name, type}` dicts                                                                                                                            |
+| `partition_by`               | —                                      | Single column name or list of columns for Delta table partitioning                                                                                                                     |
+| `scope_settings`             | `{}`                                   | Delta table properties passed to `ALTER TABLE SET TBLPROPERTIES` (e.g. compression, checkpoint intervals)                                                                              |
+| `au`                         | from profile                           | Per-model ADLA Analytics Units (parallelism) override                                                                                                                                  |
+| `priority`                   | from profile                           | Per-model ADLA job priority override                                                                                                                                                   |
+| `job_timeout_seconds`        | from profile                           | Per-model job timeout override (seconds)                                                                                                                                               |
+| `scope_feature_previews`     | `"EnableDeltaTableDynamicInsert:on"`   | Per-model SCOPE feature preview flags override                                                                                                                                         |
 
 `dbt retry` re-runs failed batches. `dbt run --full-refresh` resets the checkpoint and reprocesses all files.
 

--- a/dbt/adapters/scope/adls_gen1_client.py
+++ b/dbt/adapters/scope/adls_gen1_client.py
@@ -110,6 +110,8 @@ class AdlsGen1Client:
         self._account = account
         self._lock_file = lock_file
         self._fs: adls_core.AzureDLFileSystem | None = None
+        self._file_cache: dict[tuple[str, str | None], list[FileInfo]] = {}
+        self._enrichment_cache: dict[str, tuple[int, tuple[str, ...]]] = {}
 
     def _get_fs(self) -> adls_core.AzureDLFileSystem:
         """Lazily initialize the ADLS Gen1 filesystem client."""
@@ -132,6 +134,10 @@ class AdlsGen1Client:
     ) -> list[FileInfo]:
         """List all files under *root*, optionally filtering by regex *pattern*.
 
+        Results are cached by ``(root, pattern)`` — repeated calls with the
+        same arguments return the cached list without hitting ADLS.  Call
+        :meth:`clear_file_cache` to invalidate.
+
         Args:
             root: ADLS Gen1 path (e.g. ``/shares/SQLDB.Prod/local/...``).
             pattern: Regex pattern to match against the file name (not full path).
@@ -142,6 +148,14 @@ class AdlsGen1Client:
         Returns:
             Sorted list of ``FileInfo`` objects (sorted by modification_time ASC).
         """
+        cache_key = (root, pattern)
+        if cache_key in self._file_cache:
+            cached = self._file_cache[cache_key]
+            log.debug(
+                f"list_files cache hit: {len(cached)} files for root={root}, pattern={pattern}"
+            )
+            return cached
+
         fs = self._get_fs()
         compiled = re.compile(pattern) if pattern else None
         log.debug(f"Listing files: account={self._account}, root={root}, pattern={pattern}")
@@ -182,7 +196,25 @@ class AdlsGen1Client:
             log.debug(f"Skipped {skipped_empty} zero-length files under {root}")
         files.sort(key=lambda f: f.modification_time)
         log.debug(f"Found {len(files)} files matching pattern under {root}")
+
+        self._file_cache[cache_key] = files
         return files
+
+    def clear_file_cache(self) -> None:
+        """Clear the file listing and enrichment caches.
+
+        Call this between models or when the underlying source files may have
+        changed and a fresh ADLS listing is needed.
+        """
+        count = len(self._file_cache)
+        enrichment_count = len(self._enrichment_cache)
+        self._file_cache.clear()
+        self._enrichment_cache.clear()
+        if count or enrichment_count:
+            log.debug(
+                f"Cleared file cache ({count} listing entries, "
+                f"{enrichment_count} enrichment entries)"
+            )
 
     @staticmethod
     def _walk(
@@ -277,29 +309,51 @@ class AdlsGen1Client:
 
         Calls :meth:`estimate_bytes` for each file and returns new
         ``FileInfo`` instances with ``estimated_bytes`` and
-        ``contributing_files`` populated.
+        ``contributing_files`` populated.  Results are cached in
+        ``_enrichment_cache`` so repeated calls for the same file skip
+        the ADLS lookups.
         """
         if not files:
             return files
 
         t0 = time.monotonic()
         enriched: list[FileInfo] = []
+        cache_hits = 0
         for f in files:
-            try:
-                est_bytes, contrib_paths = self.estimate_bytes(f.path, f.length)
+            cached = self._enrichment_cache.get(f.path)
+            if cached is not None:
+                est_bytes, contrib_paths = cached
                 enriched.append(
                     replace(
                         f,
                         estimated_bytes=est_bytes,
-                        contributing_files=tuple(contrib_paths),
+                        contributing_files=contrib_paths,
+                    )
+                )
+                cache_hits += 1
+                continue
+
+            try:
+                est_bytes, contrib_paths_list = self.estimate_bytes(f.path, f.length)
+                contrib_tuple = tuple(contrib_paths_list)
+                self._enrichment_cache[f.path] = (est_bytes, contrib_tuple)
+                enriched.append(
+                    replace(
+                        f,
+                        estimated_bytes=est_bytes,
+                        contributing_files=contrib_tuple,
                     )
                 )
             except Exception:
                 log.warning(f"Failed to estimate bytes for {f.path} — using file length")
+                self._enrichment_cache[f.path] = (f.length, ())
                 enriched.append(replace(f, estimated_bytes=f.length))
 
         elapsed_ms = (time.monotonic() - t0) * 1000
-        log.debug(f"enrich_with_estimates: {len(enriched)} files enriched in {elapsed_ms:.1f} ms")
+        log.debug(
+            f"enrich_with_estimates: {len(enriched)} files enriched in {elapsed_ms:.1f} ms "
+            f"({cache_hits} cache hits, {len(enriched) - cache_hits} ADLS lookups)"
+        )
         return enriched
 
     @staticmethod

--- a/dbt/adapters/scope/connections.py
+++ b/dbt/adapters/scope/connections.py
@@ -6,7 +6,8 @@ import time
 import uuid
 from contextlib import contextmanager
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, ClassVar
+from urllib.parse import quote as url_quote
 
 import agate
 import requests
@@ -33,6 +34,9 @@ API_VERSION = "2017-09-01-preview"
 # Terminal ADLA job states
 _TERMINAL_STATES = {"Ended"}
 _SUCCESS_RESULTS = {"Succeeded"}
+
+# Namespace for deterministic UUID generation (pipeline and recurrence IDs)
+_UUID_NAMESPACE = uuid.NAMESPACE_DNS
 
 
 @dataclass
@@ -76,6 +80,14 @@ class ADLAJob:
 class ScopeConnectionHandle:
     """Wraps an ADLA REST client with credential caching."""
 
+    # Unique per Python process (= per dbt invocation).  Shared across all
+    # connections/threads so that every job submitted in one run carries the
+    # same runId.
+    _run_id: ClassVar[str] = str(uuid.uuid4())
+
+    # Models whose orphaned jobs have already been cancelled in this run.
+    _cancelled_models: ClassVar[set[str]] = set()
+
     def __init__(self, credentials: ScopeCredentials) -> None:
         self._credentials = credentials
         self._account = credentials.adla_account
@@ -89,13 +101,24 @@ class ScopeConnectionHandle:
         self._next_job_au: int | None = None
         self._next_job_priority: int | None = None
         self._next_job_max_wait: int | None = None
+        self._next_job_model_name: str | None = None
+
+        # Deterministic pipeline ID derived from the ADLA account name
+        self._pipeline_id = str(uuid.uuid5(_UUID_NAMESPACE, self._account))
 
     # -- Job operations -----------------------------------------------
 
-    def submit_job(self, name: str, script: str, au: int, priority: int) -> ADLAJob:
+    def submit_job(
+        self,
+        name: str,
+        script: str,
+        au: int,
+        priority: int,
+        model_name: str | None = None,
+    ) -> ADLAJob:
         job_id = str(uuid.uuid4())
         url = f"{self._base_url}/jobs/{job_id}?api-version={API_VERSION}"
-        body = {
+        body: dict[str, Any] = {
             "jobId": job_id,
             "name": name,
             "type": "Scope",
@@ -103,6 +126,15 @@ class ScopeConnectionHandle:
             "priority": priority,
             "properties": {"type": "Scope", "script": script},
         }
+        if model_name:
+            body["related"] = {
+                "pipelineId": self._pipeline_id,
+                "pipelineName": "dbt-scope",
+                "pipelineUri": "https://github.com/microsoft/dbt-scope",
+                "runId": ScopeConnectionHandle._run_id,
+                "recurrenceId": str(uuid.uuid5(_UUID_NAMESPACE, model_name)),
+                "recurrenceName": model_name,
+            }
         log.debug(f"Submitting SCOPE job '{name}' (AU={au}) → {job_id}")
         log.debug(f"SCOPE script for '{name}':\n{script}")
         resp = self._request("PUT", url, json=body)
@@ -116,10 +148,91 @@ class ScopeConnectionHandle:
         job.update_from_response(resp)
         return job
 
-    def cancel_job(self, job_id: str) -> None:
+    def cancel_job(
+        self,
+        job_id: str,
+        poll_interval: int = 2,
+        max_wait: int = 120,
+    ) -> None:
+        """Cancel an ADLA job and poll until it reaches a terminal state.
+
+        The ADLA CancelJob API is asynchronous — it returns immediately while
+        the job transitions through ``Finalizing`` before reaching ``Ended``.
+        This method blocks until the job is terminal or *max_wait* is exceeded.
+        """
         url = f"{self._base_url}/jobs/{job_id}/CancelJob?api-version={API_VERSION}"
         log.debug(f"Cancelling ADLA job {job_id}")
         self._request("POST", url)
+
+        # Poll until the job reaches a terminal state
+        start = time.monotonic()
+        while True:
+            elapsed = time.monotonic() - start
+            if elapsed >= max_wait:
+                log.warning(
+                    f"Timed out waiting for job {job_id} to finish cancelling "
+                    f"after {elapsed:.0f}s — proceeding anyway"
+                )
+                return
+            time.sleep(poll_interval)
+            poll_url = f"{self._base_url}/jobs/{job_id}?api-version={API_VERSION}"
+            resp = self._request("GET", poll_url)
+            state = resp.get("state", "")
+            if state in _TERMINAL_STATES:
+                log.debug(
+                    f"Job {job_id} cancel confirmed: state={state}, "
+                    f"result={resp.get('result')} ({elapsed:.1f}s)"
+                )
+                return
+
+    def list_jobs(self, filter_expr: str | None = None, top: int = 100) -> list[dict[str, Any]]:
+        """List ADLA jobs, optionally filtered by an OData ``$filter`` expression."""
+        url = f"{self._base_url}/Jobs?api-version={API_VERSION}&$top={top}"
+        if filter_expr:
+            url += f"&$filter={url_quote(filter_expr)}"
+        resp = self._request("GET", url)
+        return resp.get("value", [])
+
+    def cancel_orphaned_jobs(self, model_name: str) -> list[str]:
+        """Cancel all active ADLA jobs whose name starts with ``{model_name}_``.
+
+        Best-effort: individual cancellation failures are logged but do not
+        propagate.  Returns a list of cancelled job IDs.
+        """
+        if model_name in ScopeConnectionHandle._cancelled_models:
+            return []
+
+        filter_expr = f"startswith(name,'{model_name}_') and state ne 'Ended'"
+        try:
+            active_jobs = self.list_jobs(filter_expr=filter_expr)
+        except Exception as exc:
+            log.warning(
+                f"Failed to list active ADLA jobs for model '{model_name}' "
+                f"— skipping orphan cancellation: {exc}"
+            )
+            ScopeConnectionHandle._cancelled_models.add(model_name)
+            return []
+
+        cancelled: list[str] = []
+        for job in active_jobs:
+            job_id = job.get("jobId", "")
+            job_name = job.get("name", "")
+            try:
+                log.info(f"Cancelling orphaned ADLA job '{job_name}' ({job_id})")
+                self.cancel_job(job_id)
+                cancelled.append(job_id)
+            except Exception as exc:
+                log.warning(
+                    f"Failed to cancel orphaned job '{job_name}' ({job_id}) — continuing: {exc}"
+                )
+
+        if cancelled:
+            log.info(f"Cancelled {len(cancelled)} orphaned ADLA job(s) for model '{model_name}'")
+        else:
+            log.debug(f"No orphaned ADLA jobs found for model '{model_name}'")
+
+        ScopeConnectionHandle._cancelled_models.add(model_name)
+        return cancelled
 
     def submit_and_wait(
         self,
@@ -129,9 +242,10 @@ class ScopeConnectionHandle:
         priority: int,
         poll_interval: int = 5,
         max_wait: int = 3600,
+        model_name: str | None = None,
     ) -> ADLAJob:
         """Submit a SCOPE job and poll until terminal."""
-        job = self.submit_job(name, script, au, priority)
+        job = self.submit_job(name, script, au, priority, model_name=model_name)
         start = time.monotonic()
         last_state = job.state
 
@@ -176,6 +290,9 @@ class ScopeConnectionHandle:
             raise DbtDatabaseError(
                 f"ADLA API {method} {url} returned {resp.status_code}: {resp.text[:500]}"
             )
+        # Some endpoints (e.g. CancelJob) return 200 with an empty body
+        if not resp.content:
+            return {}
         return resp.json()
 
     @staticmethod
@@ -266,10 +383,19 @@ class ScopeConnectionManager(BaseConnectionManager):
             effective_au = handle._next_job_au or credentials.au
             effective_priority = handle._next_job_priority or credentials.priority
             effective_max_wait = handle._next_job_max_wait or credentials.max_wait_seconds
+            effective_model_name = handle._next_job_model_name
             handle._next_job_name = None
             handle._next_job_au = None
             handle._next_job_priority = None
             handle._next_job_max_wait = None
+            # Note: _next_job_model_name is NOT cleared — it persists across
+            # batches so that every job in the same materialization gets the
+            # correct ``related`` metadata.
+
+            # Cancel orphaned ADLA jobs for this model (best-effort, first time only)
+            if effective_model_name:
+                handle.cancel_orphaned_jobs(effective_model_name)
+
             job = handle.submit_and_wait(
                 name=effective_name,
                 script=sql,
@@ -277,6 +403,7 @@ class ScopeConnectionManager(BaseConnectionManager):
                 priority=effective_priority,
                 poll_interval=credentials.poll_interval_seconds,
                 max_wait=effective_max_wait,
+                model_name=effective_model_name,
             )
 
         response = AdapterResponse(

--- a/dbt/adapters/scope/connections.py
+++ b/dbt/adapters/scope/connections.py
@@ -100,7 +100,7 @@ class ScopeConnectionHandle:
         self._next_job_name: str | None = None
         self._next_job_au: int | None = None
         self._next_job_priority: int | None = None
-        self._next_job_max_wait: int | None = None
+        self._next_job_timeout_seconds: int | None = None
         self._next_job_model_name: str | None = None
 
         # Deterministic pipeline ID derived from the ADLA account name
@@ -382,12 +382,12 @@ class ScopeConnectionManager(BaseConnectionManager):
             effective_name = handle._next_job_name or job_name
             effective_au = handle._next_job_au or credentials.au
             effective_priority = handle._next_job_priority or credentials.priority
-            effective_max_wait = handle._next_job_max_wait or credentials.max_wait_seconds
+            effective_max_wait = handle._next_job_timeout_seconds or credentials.job_timeout_seconds
             effective_model_name = handle._next_job_model_name
             handle._next_job_name = None
             handle._next_job_au = None
             handle._next_job_priority = None
-            handle._next_job_max_wait = None
+            handle._next_job_timeout_seconds = None
             # Note: _next_job_model_name is NOT cleared — it persists across
             # batches so that every job in the same materialization gets the
             # correct ``related`` metadata.

--- a/dbt/adapters/scope/credentials.py
+++ b/dbt/adapters/scope/credentials.py
@@ -36,7 +36,7 @@ class ScopeCredentials(Credentials):
     au: int = 100
     priority: int = 1
     poll_interval_seconds: int = 5
-    max_wait_seconds: int = 3600
+    job_timeout_seconds: int = 36_000
     max_files_per_trigger: int = 50
     max_bytes_per_trigger: int = 10_737_418_240_000  # ~10 TB
     http_timeout_seconds: int = 30

--- a/dbt/adapters/scope/impl.py
+++ b/dbt/adapters/scope/impl.py
@@ -380,11 +380,11 @@ class ScopeAdapter(BaseAdapter):
         return getattr(self, "_last_total_batches", 0)
 
     @available
-    def set_next_job_max_wait(self, max_wait: int) -> None:
-        """Set the poll timeout for the next ``execute()`` call on this thread."""
+    def set_next_job_timeout_seconds(self, timeout: int) -> None:
+        """Set the job timeout for the next ``execute()`` call on this thread."""
         connection = self.connections.get_thread_connection()
         handle: ScopeConnectionHandle = connection.handle  # type: ignore[assignment]
-        handle._next_job_max_wait = max_wait
+        handle._next_job_timeout_seconds = timeout
 
     @available
     def discover_files(
@@ -594,31 +594,6 @@ class ScopeAdapter(BaseAdapter):
             starting_timestamp=starting_timestamp,
         )
         return len(files) > 0
-
-    def submit_scope_script(
-        self,
-        script: str,
-        job_name: str = "dbt-scope",
-        au: int | None = None,
-        priority: int | None = None,
-    ) -> str:
-        """Submit a SCOPE script to ADLA and wait for completion.
-
-        Returns the job ID on success.
-        """
-        connection = self.connections.get_thread_connection()
-        handle: ScopeConnectionHandle = connection.handle  # type: ignore[assignment]
-        creds = self._credentials()
-
-        job = handle.submit_and_wait(
-            name=job_name,
-            script=script,
-            au=au or creds.au,
-            priority=priority or creds.priority,
-            poll_interval=creds.poll_interval_seconds,
-            max_wait=creds.max_wait_seconds,
-        )
-        return job.job_id
 
     def build_script_config(self, model_config: dict[str, Any], table_name: str) -> ScriptConfig:
         """Build a ``ScriptConfig`` from dbt model config + credentials."""

--- a/dbt/adapters/scope/impl.py
+++ b/dbt/adapters/scope/impl.py
@@ -468,6 +468,13 @@ class ScopeAdapter(BaseAdapter):
         # Enrich with byte estimates (SSv5/v6 sibling folder detection)
         all_unprocessed = self._get_gen1_client().enrich_with_estimates(all_unprocessed)
 
+        # Cache enriched FileInfo objects for use by update_checkpoint()
+        # (cumulative across batch iterations — new files are added, not replaced)
+        if not hasattr(self, "_discovered_file_infos"):
+            self._discovered_file_infos: dict[str, FileInfo] = {}
+        for f in all_unprocessed:
+            self._discovered_file_infos[f.path] = f
+
         # Pre-compute total batch count from the full unprocessed list
         self._last_total_batches = _count_batches(
             all_unprocessed, max_files_per_trigger, max_bytes_per_trigger
@@ -521,11 +528,10 @@ class ScopeAdapter(BaseAdapter):
     ) -> None:
         """Update the watermark checkpoint after a successful SCOPE job.
 
-        Iterates the cross-product of *source_roots* x *source_patterns* to
-        reconstruct ``FileInfo`` objects for the processed files, then writes
-        the checkpoint.  Also writes per-batch JSONL to
-        ``_checkpoint/sources/{batch_id}``, triggers compaction at interval
-        boundaries, and enforces retention.
+        Uses cached ``FileInfo`` objects from :meth:`discover_files` when
+        available, falling back to ADLS listing only for paths not in cache.
+        Also writes per-batch JSONL to ``_checkpoint/sources/{batch_id}``,
+        triggers compaction at interval boundaries, and enforces retention.
         """
         gen1 = self._get_gen1_client()
         checkpoint = self._get_checkpoint_manager()
@@ -533,18 +539,32 @@ class ScopeAdapter(BaseAdapter):
         # Get current watermark
         current = checkpoint.read_watermark(delta_location)
 
-        # Reconstruct FileInfo objects across all rootxpattern combos
-        target_paths = set(file_paths)
-        seen_paths: set[str] = set()
+        # Look up FileInfo from the discovery cache first
+        cache = getattr(self, "_discovered_file_infos", {})
         processed: list[FileInfo] = []
+        uncached_paths: set[str] = set()
 
-        for root in source_roots:
-            for pattern in source_patterns:
-                all_files = gen1.list_files(root, pattern=pattern)
-                for f in all_files:
-                    if f.path in target_paths and f.path not in seen_paths:
-                        seen_paths.add(f.path)
-                        processed.append(f)
+        for path in file_paths:
+            cached_info = cache.get(path)
+            if cached_info is not None:
+                processed.append(cached_info)
+            else:
+                uncached_paths.add(path)
+
+        # Fallback: list files from ADLS for any paths not in cache
+        if uncached_paths:
+            log.debug(
+                f"update_checkpoint: {len(uncached_paths)} paths not in cache, "
+                f"falling back to ADLS listing"
+            )
+            seen_paths: set[str] = set()
+            for root in source_roots:
+                for pattern in source_patterns:
+                    all_files = gen1.list_files(root, pattern=pattern)
+                    for f in all_files:
+                        if f.path in uncached_paths and f.path not in seen_paths:
+                            seen_paths.add(f.path)
+                            processed.append(f)
 
         if not processed:
             log.warning("update_checkpoint: no matching files found for paths")
@@ -574,6 +594,17 @@ class ScopeAdapter(BaseAdapter):
     def delete_checkpoint(self, delta_location: str) -> None:
         """Delete the watermark checkpoint (for full refresh)."""
         self._get_checkpoint_manager().delete_watermark(delta_location)
+
+    @available
+    def clear_file_discovery_cache(self) -> None:
+        """Clear all file listing and enrichment caches.
+
+        Call between models to force a fresh ADLS listing on the next
+        :meth:`discover_files` invocation.
+        """
+        self._get_gen1_client().clear_file_cache()
+        if hasattr(self, "_discovered_file_infos"):
+            self._discovered_file_infos.clear()
 
     @available
     def has_unprocessed_files(

--- a/dbt/adapters/scope/impl.py
+++ b/dbt/adapters/scope/impl.py
@@ -347,6 +347,20 @@ class ScopeAdapter(BaseAdapter):
         handle._next_job_name = name
 
     @available
+    def set_next_job_model_name(self, model_name: str) -> None:
+        """Set the dbt model name for the next ``execute()`` call on this thread.
+
+        Used for two purposes:
+        1. Orphan cancellation — active ADLA jobs matching this model are cancelled
+           before the first job submission (best-effort, once per model per run).
+        2. ``related`` metadata — every submitted job carries ``recurrenceId`` and
+           ``recurrenceName`` derived from this model name.
+        """
+        connection = self.connections.get_thread_connection()
+        handle: ScopeConnectionHandle = connection.handle  # type: ignore[assignment]
+        handle._next_job_model_name = model_name
+
+    @available
     def set_next_job_au(self, au: int) -> None:
         """Set the AU (parallelism) for the next ``execute()`` call on this thread."""
         connection = self.connections.get_thread_connection()

--- a/dbt/include/scope/macros/materializations/incremental.sql
+++ b/dbt/include/scope/macros/materializations/incremental.sql
@@ -103,7 +103,7 @@
                 {% do adapter.set_next_job_name(identifier ~ "_" ~ job_suffix) %}
                 {% if config.get('au') %}{% do adapter.set_next_job_au(config.get('au') | int) %}{% endif %}
                 {% if config.get('priority') %}{% do adapter.set_next_job_priority(config.get('priority') | int) %}{% endif %}
-                {% if config.get('query_poll_timeout_seconds') %}{% do adapter.set_next_job_max_wait(config.get('query_poll_timeout_seconds') | int) %}{% endif %}
+                {% if config.get('job_timeout_seconds') %}{% do adapter.set_next_job_timeout_seconds(config.get('job_timeout_seconds') | int) %}{% endif %}
                 {%- call statement('main') -%}
                     {{ scope_script }}
                 {%- endcall -%}

--- a/dbt/include/scope/macros/materializations/incremental.sql
+++ b/dbt/include/scope/macros/materializations/incremental.sql
@@ -53,6 +53,9 @@
         {% do adapter.delete_checkpoint(delta_location) %}
     {%- endif -%}
 
+    {# -- Register model name for orphan cancellation + related metadata -- #}
+    {% do adapter.set_next_job_model_name(identifier) %}
+
     {# -- Batching loop: discover → submit → checkpoint → repeat -- #}
     {%- set ns = namespace(
         batch_num=0,

--- a/dbt/include/scope/macros/materializations/table.sql
+++ b/dbt/include/scope/macros/materializations/table.sql
@@ -80,7 +80,7 @@
                 {% do adapter.set_next_job_name(identifier ~ "_" ~ job_suffix) %}
                 {% if config.get('au') %}{% do adapter.set_next_job_au(config.get('au') | int) %}{% endif %}
                 {% if config.get('priority') %}{% do adapter.set_next_job_priority(config.get('priority') | int) %}{% endif %}
-                {% if config.get('query_poll_timeout_seconds') %}{% do adapter.set_next_job_max_wait(config.get('query_poll_timeout_seconds') | int) %}{% endif %}
+                {% if config.get('job_timeout_seconds') %}{% do adapter.set_next_job_timeout_seconds(config.get('job_timeout_seconds') | int) %}{% endif %}
                 {%- call statement('main') -%}
                     {{ scope_script }}
                 {%- endcall -%}

--- a/dbt/include/scope/macros/materializations/table.sql
+++ b/dbt/include/scope/macros/materializations/table.sql
@@ -34,6 +34,9 @@
     {# -- Delete checkpoint for full refresh -- #}
     {% do adapter.delete_checkpoint(delta_location) %}
 
+    {# -- Register model name for orphan cancellation + related metadata -- #}
+    {% do adapter.set_next_job_model_name(identifier) %}
+
     {# -- Batching loop: discover → submit → checkpoint → repeat -- #}
     {# NOTE: file_batch MUST live in the namespace — see incremental.sql for details. #}
     {%- set ns = namespace(

--- a/tests/integration/dbt_project/profiles.yml
+++ b/tests/integration/dbt_project/profiles.yml
@@ -16,6 +16,6 @@ dbt_scope_test:
       au: "{{ env_var('SCOPE_AU', '5') | int }}"
       priority: "{{ env_var('SCOPE_PRIORITY', '1') | int }}"
       poll_interval_seconds: 5
-      max_wait_seconds: 3600
+      job_timeout_seconds: 36000
       http_timeout_seconds: 30
       http_retries: 3

--- a/tests/unit/test_credentials.py
+++ b/tests/unit/test_credentials.py
@@ -27,7 +27,7 @@ class TestScopeCredentials:
         assert creds.au == 100
         assert creds.priority == 1
         assert creds.poll_interval_seconds == 5
-        assert creds.max_wait_seconds == 3600
+        assert creds.job_timeout_seconds == 36_000
         assert creds.delta_base_path == "delta"
 
     def test_custom_values(self):

--- a/tests/unit/test_file_cache.py
+++ b/tests/unit/test_file_cache.py
@@ -1,0 +1,264 @@
+"""Unit tests for file listing and enrichment caching.
+
+Tests the cache behavior in AdlsGen1Client.list_files() and
+enrich_with_estimates(), and the adapter-level FileInfo cache used
+by update_checkpoint() to avoid redundant ADLS listings.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock, patch
+
+from dbt.adapters.scope.adls_gen1_client import AdlsGen1Client, FileInfo
+from dbt.adapters.scope.checkpoint import Watermark
+from dbt.adapters.scope.file_tracker import FileTracker
+
+NOW = datetime(2026, 4, 1, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _make_file(name: str, mod_time: datetime, length: int = 1000) -> FileInfo:
+    return FileInfo(
+        path=f"/shares/test/{name}",
+        name=name,
+        length=length,
+        modification_time=mod_time,
+        raw={
+            "name": f"shares/test/{name}",
+            "length": length,
+            "type": "FILE",
+            "modificationTime": int(mod_time.timestamp() * 1000),
+        },
+    )
+
+
+class TestAdlsGen1ClientListFilesCache:
+    """Test that list_files() caches results by (root, pattern)."""
+
+    def test_cache_hit_returns_same_result(self):
+        """Second call with same args returns cached list without ADLS call."""
+        client = AdlsGen1Client(account="test")
+
+        files = [_make_file("a.ss", NOW - timedelta(hours=2))]
+
+        mock_fs = MagicMock()
+        mock_fs.ls.return_value = [f.raw for f in files]
+
+        with patch.object(client, "_get_fs", return_value=mock_fs):
+            result1 = client.list_files("/shares/test", pattern=r".*\.ss$")
+            result2 = client.list_files("/shares/test", pattern=r".*\.ss$")
+
+        assert len(result1) == 1
+        assert len(result2) == 1
+        assert result1[0].path == result2[0].path
+        # ADLS ls should be called only once (first call)
+        mock_fs.ls.assert_called_once()
+
+    def test_different_pattern_is_separate_cache_entry(self):
+        """Different patterns are cached independently."""
+        client = AdlsGen1Client(account="test")
+
+        ss_files = [_make_file("a.ss", NOW - timedelta(hours=2))]
+        csv_files = [_make_file("b.csv", NOW - timedelta(hours=1))]
+
+        mock_fs = MagicMock()
+        mock_fs.ls.side_effect = [
+            [f.raw for f in ss_files],
+            [f.raw for f in csv_files],
+        ]
+
+        with patch.object(client, "_get_fs", return_value=mock_fs):
+            result_ss = client.list_files("/shares/test", pattern=r".*\.ss$")
+            result_csv = client.list_files("/shares/test", pattern=r".*\.csv$")
+
+        assert len(result_ss) == 1
+        assert result_ss[0].name == "a.ss"
+        assert len(result_csv) == 1
+        assert result_csv[0].name == "b.csv"
+        assert mock_fs.ls.call_count == 2
+
+    def test_different_root_is_separate_cache_entry(self):
+        """Different roots are cached independently."""
+        client = AdlsGen1Client(account="test")
+
+        root1_files = [_make_file("a.ss", NOW - timedelta(hours=2))]
+        root2_files = [_make_file("b.ss", NOW - timedelta(hours=1))]
+
+        mock_fs = MagicMock()
+        mock_fs.ls.side_effect = [
+            [f.raw for f in root1_files],
+            [f.raw for f in root2_files],
+        ]
+
+        with patch.object(client, "_get_fs", return_value=mock_fs):
+            r1 = client.list_files("/root1", pattern=r".*\.ss$")
+            r2 = client.list_files("/root2", pattern=r".*\.ss$")
+
+        assert len(r1) == 1
+        assert len(r2) == 1
+        assert mock_fs.ls.call_count == 2
+
+    def test_clear_file_cache_forces_fresh_listing(self):
+        """After clear_file_cache(), next call hits ADLS again."""
+        client = AdlsGen1Client(account="test")
+
+        files = [_make_file("a.ss", NOW - timedelta(hours=2))]
+
+        mock_fs = MagicMock()
+        mock_fs.ls.return_value = [f.raw for f in files]
+
+        with patch.object(client, "_get_fs", return_value=mock_fs):
+            client.list_files("/shares/test", pattern=r".*\.ss$")
+            assert mock_fs.ls.call_count == 1
+
+            client.clear_file_cache()
+
+            client.list_files("/shares/test", pattern=r".*\.ss$")
+            assert mock_fs.ls.call_count == 2
+
+    def test_cache_survives_multiple_calls(self):
+        """Cache hit works for many repeated calls."""
+        client = AdlsGen1Client(account="test")
+
+        files = [_make_file("a.ss", NOW - timedelta(hours=2))]
+
+        mock_fs = MagicMock()
+        mock_fs.ls.return_value = [f.raw for f in files]
+
+        with patch.object(client, "_get_fs", return_value=mock_fs):
+            for _ in range(10):
+                result = client.list_files("/shares/test", pattern=r".*\.ss$")
+                assert len(result) == 1
+
+        mock_fs.ls.assert_called_once()
+
+
+class TestAdlsGen1ClientEnrichmentCache:
+    """Test that enrich_with_estimates() caches results per file path."""
+
+    def test_enrichment_cache_hit(self):
+        """Second enrichment call for same files uses cache."""
+        client = AdlsGen1Client(account="test")
+
+        files = [_make_file("a.ss", NOW - timedelta(hours=2), length=500)]
+
+        with patch.object(client, "estimate_bytes", return_value=(1500, ["/contrib/a"])) as mock_eb:
+            result1 = client.enrich_with_estimates(files)
+            result2 = client.enrich_with_estimates(files)
+
+        assert result1[0].estimated_bytes == 1500
+        assert result2[0].estimated_bytes == 1500
+        # estimate_bytes called only once
+        mock_eb.assert_called_once()
+
+    def test_enrichment_cache_miss_for_new_files(self):
+        """New files trigger ADLS calls; already-seen files use cache."""
+        client = AdlsGen1Client(account="test")
+
+        file_a = _make_file("a.ss", NOW - timedelta(hours=2), length=500)
+        file_b = _make_file("b.ss", NOW - timedelta(hours=1), length=700)
+
+        with patch.object(client, "estimate_bytes") as mock_eb:
+            mock_eb.side_effect = [(1500, ["/contrib/a"]), (2000, ["/contrib/b"])]
+            client.enrich_with_estimates([file_a])
+            # Second call includes both — a should be cached, b is new
+            result = client.enrich_with_estimates([file_a, file_b])
+
+        assert result[0].estimated_bytes == 1500  # cached
+        assert result[1].estimated_bytes == 2000  # fresh
+        assert mock_eb.call_count == 2  # a once, b once
+
+    def test_clear_file_cache_clears_enrichment(self):
+        """clear_file_cache() also clears enrichment cache."""
+        client = AdlsGen1Client(account="test")
+
+        files = [_make_file("a.ss", NOW - timedelta(hours=2), length=500)]
+
+        with patch.object(client, "estimate_bytes", return_value=(1500, [])) as mock_eb:
+            client.enrich_with_estimates(files)
+            assert mock_eb.call_count == 1
+
+            client.clear_file_cache()
+
+            client.enrich_with_estimates(files)
+            assert mock_eb.call_count == 2  # called again after cache clear
+
+
+class TestBatchLoopCacheLifecycle:
+    """End-to-end test simulating the microbatch loop.
+
+    Verifies that LIST is called once across all batch iterations, and
+    update_checkpoint can use cached FileInfo objects.
+    """
+
+    def test_batch_loop_lists_once(self):
+        """Simulates 3 batch iterations — ADLS LIST should be called once."""
+        gen1 = MagicMock(spec=AdlsGen1Client)
+        checkpoint_mgr = MagicMock()
+        tracker = FileTracker(gen1, checkpoint_mgr)
+
+        # 6 files, will be batched into 3 batches of 2
+        all_files = [
+            _make_file(f"{i}.ss", NOW - timedelta(hours=6 - i), length=100) for i in range(6)
+        ]
+        gen1.list_files.return_value = all_files
+        gen1.enrich_with_estimates.side_effect = lambda files: files
+
+        # Simulate discover_files + update_checkpoint loop
+        discovered_cache: dict[str, FileInfo] = {}
+        watermark: Watermark | None = None
+
+        for batch_num in range(3):
+            # discover_files
+            unprocessed = tracker.discover_unprocessed_files(
+                root="/shares/test",
+                pattern=r".*\.ss$",
+                watermark=watermark,
+                safety_buffer_seconds=0,
+            )
+            unprocessed.sort(key=lambda f: f.modification_time)
+
+            enriched = gen1.enrich_with_estimates(unprocessed)
+            for f in enriched:
+                discovered_cache[f.path] = f
+
+            batch = FileTracker.get_next_batch(enriched, max_files_per_trigger=2)
+            assert len(batch) == 2, f"Batch {batch_num} should have 2 files"
+
+            # update_checkpoint — uses cache, no re-listing
+            processed = [discovered_cache[f.path] for f in batch]
+            watermark = FileTracker.compute_new_watermark(processed, watermark)
+
+        # ADLS list_files should have been called once per discover call (3 times)
+        # But with the actual AdlsGen1Client cache, it would be 1 call total.
+        # Here we're testing the pattern, not the cache (mock doesn't cache).
+        assert gen1.list_files.call_count == 3  # 3 discover calls, each calls list_files
+        # The real optimization is tested in TestAdlsGen1ClientListFilesCache above
+
+    def test_update_checkpoint_uses_cached_fileinfo(self):
+        """update_checkpoint lookup from _discovered_file_infos works correctly."""
+        files = [
+            _make_file("a.ss", NOW - timedelta(hours=2), length=500),
+            _make_file("b.ss", NOW - timedelta(hours=1), length=700),
+        ]
+
+        # Simulate the cache built by discover_files
+        cache: dict[str, FileInfo] = {f.path: f for f in files}
+
+        # Look up FileInfo for specific paths (what update_checkpoint does)
+        batch_paths = [files[0].path]
+        processed = [cache[p] for p in batch_paths if p in cache]
+
+        assert len(processed) == 1
+        assert processed[0].name == "a.ss"
+        assert processed[0].modification_time == files[0].modification_time
+
+    def test_uncached_paths_fall_back(self):
+        """Paths not in cache require a fallback listing (defensive)."""
+        cache: dict[str, FileInfo] = {}
+
+        # File not in cache
+        unknown_path = "/shares/test/unknown.ss"
+        processed = [cache.get(unknown_path)]
+
+        assert processed == [None]  # Not found — triggers fallback in real code

--- a/tests/unit/test_job_lifecycle.py
+++ b/tests/unit/test_job_lifecycle.py
@@ -369,7 +369,7 @@ class TestExecuteOrphanCancellation:
         handle._next_job_name = None
         handle._next_job_au = None
         handle._next_job_priority = None
-        handle._next_job_max_wait = None
+        handle._next_job_timeout_seconds = None
         handle._next_job_model_name = None
         handle.submit_and_wait = MagicMock()
         handle.submit_and_wait.return_value = MagicMock(job_id="test-id", result="Succeeded")
@@ -378,7 +378,7 @@ class TestExecuteOrphanCancellation:
         connection = MagicMock()
         connection.handle = handle
         connection.credentials = MagicMock(
-            au=100, priority=1, poll_interval_seconds=5, max_wait_seconds=60
+            au=100, priority=1, poll_interval_seconds=5, job_timeout_seconds=60
         )
         mgr.get_thread_connection.return_value = connection
         return mgr, handle

--- a/tests/unit/test_job_lifecycle.py
+++ b/tests/unit/test_job_lifecycle.py
@@ -1,0 +1,454 @@
+"""Tests for ADLA job lifecycle: related metadata, list_jobs, and orphan cancellation."""
+
+from __future__ import annotations
+
+import uuid
+from contextlib import contextmanager
+from unittest.mock import MagicMock, call, patch
+from urllib.parse import quote as url_quote
+
+import pytest
+
+from dbt.adapters.scope.connections import (
+    _UUID_NAMESPACE,
+    ScopeConnectionHandle,
+    ScopeConnectionManager,
+)
+
+# A minimal non-comment SCOPE script that won't be skipped by execute()
+_DUMMY_SCRIPT = '// SCOPE script\nSET @@FeaturePreviews = "EnableDeltaTableDynamicInsert:on";'
+
+
+@pytest.fixture(autouse=True)
+def _reset_class_state():
+    """Reset class-level state between tests."""
+    old_run_id = ScopeConnectionHandle._run_id
+    old_cancelled = ScopeConnectionHandle._cancelled_models.copy()
+    yield
+    ScopeConnectionHandle._run_id = old_run_id
+    ScopeConnectionHandle._cancelled_models = old_cancelled
+
+
+def _make_handle(account: str = "test-adla") -> ScopeConnectionHandle:
+    """Create a ScopeConnectionHandle with mocked internals."""
+    creds = MagicMock()
+    creds.adla_account = account
+    creds.http_timeout_seconds = 30
+    creds.http_retries = 3
+    with patch.object(ScopeConnectionHandle, "_build_session", return_value=MagicMock()):
+        return ScopeConnectionHandle(creds)
+
+
+# =====================================================================
+# Part A: related metadata
+# =====================================================================
+
+
+class TestRunId:
+    """_run_id is a class-level UUID shared across all instances."""
+
+    def test_is_valid_uuid(self):
+        uuid.UUID(ScopeConnectionHandle._run_id)  # should not raise
+
+    def test_same_across_instances(self):
+        h1 = _make_handle("acct-a")
+        h2 = _make_handle("acct-b")
+        assert h1._run_id == h2._run_id
+        assert h1._run_id is ScopeConnectionHandle._run_id
+
+
+class TestPipelineId:
+    """_pipeline_id is deterministic from the ADLA account name."""
+
+    def test_deterministic(self):
+        h1 = _make_handle("my-adla-account")
+        h2 = _make_handle("my-adla-account")
+        assert h1._pipeline_id == h2._pipeline_id
+
+    def test_differs_for_different_accounts(self):
+        h1 = _make_handle("account-a")
+        h2 = _make_handle("account-b")
+        assert h1._pipeline_id != h2._pipeline_id
+
+    def test_is_uuid5_of_account(self):
+        handle = _make_handle("my-adla")
+        expected = str(uuid.uuid5(_UUID_NAMESPACE, "my-adla"))
+        assert handle._pipeline_id == expected
+
+
+class TestRecurrenceId:
+    """recurrenceId in related metadata is deterministic from model name."""
+
+    def test_deterministic_for_same_model(self):
+        id1 = str(uuid.uuid5(_UUID_NAMESPACE, "events_daily"))
+        id2 = str(uuid.uuid5(_UUID_NAMESPACE, "events_daily"))
+        assert id1 == id2
+
+    def test_differs_for_different_models(self):
+        id1 = str(uuid.uuid5(_UUID_NAMESPACE, "events_daily"))
+        id2 = str(uuid.uuid5(_UUID_NAMESPACE, "user_sessions"))
+        assert id1 != id2
+
+
+class TestSubmitJobRelatedMetadata:
+    """submit_job includes related metadata when model_name is provided."""
+
+    def test_includes_related_when_model_name_set(self):
+        handle = _make_handle("test-adla")
+        handle._request = MagicMock(return_value={"state": "Preparing"})
+
+        handle.submit_job(
+            name="events_daily_full-refresh_batch_1_of_1_files_5",
+            script="// script",
+            au=100,
+            priority=1,
+            model_name="events_daily",
+        )
+
+        call_kwargs = handle._request.call_args
+        body = call_kwargs.kwargs["json"]
+        assert "related" in body
+        related = body["related"]
+        assert related["pipelineId"] == handle._pipeline_id
+        assert related["pipelineName"] == "dbt-scope"
+        assert related["pipelineUri"] == "https://github.com/microsoft/dbt-scope"
+        assert related["runId"] == ScopeConnectionHandle._run_id
+        assert related["recurrenceId"] == str(uuid.uuid5(_UUID_NAMESPACE, "events_daily"))
+        assert related["recurrenceName"] == "events_daily"
+
+    def test_no_related_when_model_name_is_none(self):
+        handle = _make_handle("test-adla")
+        handle._request = MagicMock(return_value={"state": "Preparing"})
+
+        handle.submit_job(
+            name="dbt-scope",
+            script="// script",
+            au=100,
+            priority=1,
+            model_name=None,
+        )
+
+        body = handle._request.call_args.kwargs["json"]
+        assert "related" not in body
+
+    def test_no_related_when_model_name_not_provided(self):
+        handle = _make_handle("test-adla")
+        handle._request = MagicMock(return_value={"state": "Preparing"})
+
+        handle.submit_job(
+            name="dbt-scope",
+            script="// script",
+            au=100,
+            priority=1,
+        )
+
+        body = handle._request.call_args.kwargs["json"]
+        assert "related" not in body
+
+
+# =====================================================================
+# Part B: list_jobs and cancel_orphaned_jobs
+# =====================================================================
+
+
+class TestListJobs:
+    """list_jobs builds correct ADLA API URLs."""
+
+    def test_url_without_filter(self):
+        handle = _make_handle()
+        handle._request = MagicMock(return_value={"value": []})
+
+        result = handle.list_jobs()
+
+        assert result == []
+        url = handle._request.call_args.args[1]
+        assert "/Jobs?" in url
+        assert "$top=100" in url
+        assert "$filter" not in url
+
+    def test_url_with_filter(self):
+        handle = _make_handle()
+        handle._request = MagicMock(return_value={"value": []})
+
+        filter_expr = "startswith(name,'events_') and state ne 'Ended'"
+        handle.list_jobs(filter_expr=filter_expr)
+
+        url = handle._request.call_args.args[1]
+        assert f"$filter={url_quote(filter_expr)}" in url
+
+    def test_custom_top(self):
+        handle = _make_handle()
+        handle._request = MagicMock(return_value={"value": []})
+
+        handle.list_jobs(top=50)
+
+        url = handle._request.call_args.args[1]
+        assert "$top=50" in url
+
+    def test_returns_value_list(self):
+        handle = _make_handle()
+        jobs = [{"jobId": "j1", "name": "events_batch_1"}]
+        handle._request = MagicMock(return_value={"value": jobs})
+
+        result = handle.list_jobs()
+
+        assert result == jobs
+
+
+class TestCancelJob:
+    """cancel_job polls until the job reaches a terminal state."""
+
+    def test_polls_until_ended(self):
+        handle = _make_handle()
+        # POST (cancel) returns empty, then GET polls return Finalizing, then Ended
+        handle._request = MagicMock(
+            side_effect=[
+                {},  # POST CancelJob
+                {"state": "Finalizing", "result": None},  # GET poll 1
+                {"state": "Ended", "result": "Cancelled"},  # GET poll 2
+            ]
+        )
+
+        handle.cancel_job("job-123", poll_interval=0)
+
+        assert handle._request.call_count == 3
+        # First call is the POST cancel
+        assert handle._request.call_args_list[0].args[0] == "POST"
+        # Remaining calls are GET polls
+        assert handle._request.call_args_list[1].args[0] == "GET"
+        assert handle._request.call_args_list[2].args[0] == "GET"
+
+    def test_returns_immediately_if_already_ended(self):
+        handle = _make_handle()
+        handle._request = MagicMock(
+            side_effect=[
+                {},  # POST CancelJob
+                {"state": "Ended", "result": "Cancelled"},  # GET poll 1
+            ]
+        )
+
+        handle.cancel_job("job-123", poll_interval=0)
+
+        assert handle._request.call_count == 2
+
+    def test_times_out_gracefully(self):
+        handle = _make_handle()
+        # Never returns Ended
+        handle._request = MagicMock(return_value={"state": "Finalizing", "result": None})
+
+        # Should not raise — just logs a warning and returns
+        handle.cancel_job("job-123", poll_interval=0, max_wait=0)
+
+        # POST + at least one timeout check
+        assert handle._request.call_count >= 1
+
+
+class TestCancelOrphanedJobs:
+    """cancel_orphaned_jobs lists active jobs and cancels each."""
+
+    def test_cancels_active_jobs(self):
+        handle = _make_handle()
+        active_jobs = [
+            {"jobId": "job-1", "name": "events_daily_batch_1"},
+            {"jobId": "job-2", "name": "events_daily_batch_2"},
+        ]
+        handle.list_jobs = MagicMock(return_value=active_jobs)
+        handle.cancel_job = MagicMock()
+
+        cancelled = handle.cancel_orphaned_jobs("events_daily")
+
+        assert cancelled == ["job-1", "job-2"]
+        handle.cancel_job.assert_has_calls([call("job-1"), call("job-2")])
+
+    def test_uses_correct_filter(self):
+        handle = _make_handle()
+        handle.list_jobs = MagicMock(return_value=[])
+        handle.cancel_job = MagicMock()
+
+        handle.cancel_orphaned_jobs("my_model")
+
+        handle.list_jobs.assert_called_once_with(
+            filter_expr="startswith(name,'my_model_') and state ne 'Ended'"
+        )
+
+    def test_noop_when_no_active_jobs(self):
+        handle = _make_handle()
+        handle.list_jobs = MagicMock(return_value=[])
+        handle.cancel_job = MagicMock()
+
+        cancelled = handle.cancel_orphaned_jobs("events_daily")
+
+        assert cancelled == []
+        handle.cancel_job.assert_not_called()
+
+    def test_tracks_cancelled_models(self):
+        handle = _make_handle()
+        handle.list_jobs = MagicMock(return_value=[])
+        handle.cancel_job = MagicMock()
+
+        handle.cancel_orphaned_jobs("events_daily")
+
+        assert "events_daily" in ScopeConnectionHandle._cancelled_models
+
+    def test_skips_already_cancelled_model(self):
+        handle = _make_handle()
+        handle.list_jobs = MagicMock(return_value=[])
+        handle.cancel_job = MagicMock()
+
+        handle.cancel_orphaned_jobs("events_daily")
+        handle.list_jobs.reset_mock()
+
+        # Second call should be a no-op
+        cancelled = handle.cancel_orphaned_jobs("events_daily")
+
+        assert cancelled == []
+        handle.list_jobs.assert_not_called()
+
+    def test_different_models_cancelled_independently(self):
+        handle = _make_handle()
+        handle.list_jobs = MagicMock(return_value=[])
+        handle.cancel_job = MagicMock()
+
+        handle.cancel_orphaned_jobs("model_a")
+        handle.cancel_orphaned_jobs("model_b")
+
+        assert "model_a" in ScopeConnectionHandle._cancelled_models
+        assert "model_b" in ScopeConnectionHandle._cancelled_models
+        assert handle.list_jobs.call_count == 2
+
+    def test_list_failure_is_best_effort(self):
+        handle = _make_handle()
+        handle.list_jobs = MagicMock(side_effect=Exception("network error"))
+        handle.cancel_job = MagicMock()
+
+        # Should not raise
+        cancelled = handle.cancel_orphaned_jobs("events_daily")
+
+        assert cancelled == []
+        # Model should still be marked to avoid retrying
+        assert "events_daily" in ScopeConnectionHandle._cancelled_models
+
+    def test_individual_cancel_failure_continues(self):
+        handle = _make_handle()
+        active_jobs = [
+            {"jobId": "job-1", "name": "events_daily_batch_1"},
+            {"jobId": "job-2", "name": "events_daily_batch_2"},
+            {"jobId": "job-3", "name": "events_daily_batch_3"},
+        ]
+        handle.list_jobs = MagicMock(return_value=active_jobs)
+        handle.cancel_job = MagicMock(side_effect=[None, Exception("cancel failed"), None])
+
+        cancelled = handle.cancel_orphaned_jobs("events_daily")
+
+        # job-1 and job-3 succeeded, job-2 failed but didn't stop the loop
+        assert cancelled == ["job-1", "job-3"]
+        assert handle.cancel_job.call_count == 3
+
+
+# =====================================================================
+# Integration: execute() triggers orphan cancellation
+# =====================================================================
+
+
+class TestExecuteOrphanCancellation:
+    """ScopeConnectionManager.execute() cancels orphans on first call per model."""
+
+    @pytest.fixture
+    def mock_manager(self):
+        """Create a ScopeConnectionManager with mocked internals."""
+        mgr = MagicMock(spec=ScopeConnectionManager)
+        mgr.execute = ScopeConnectionManager.execute.__get__(mgr, ScopeConnectionManager)
+
+        @contextmanager
+        def _exception_handler(sql):
+            yield
+
+        mgr.exception_handler = _exception_handler
+
+        handle = MagicMock()
+        handle._next_job_name = None
+        handle._next_job_au = None
+        handle._next_job_priority = None
+        handle._next_job_max_wait = None
+        handle._next_job_model_name = None
+        handle.submit_and_wait = MagicMock()
+        handle.submit_and_wait.return_value = MagicMock(job_id="test-id", result="Succeeded")
+        handle.cancel_orphaned_jobs = MagicMock(return_value=[])
+
+        connection = MagicMock()
+        connection.handle = handle
+        connection.credentials = MagicMock(
+            au=100, priority=1, poll_interval_seconds=5, max_wait_seconds=60
+        )
+        mgr.get_thread_connection.return_value = connection
+        return mgr, handle
+
+    def test_cancels_orphans_when_model_name_set(self, mock_manager):
+        mgr, handle = mock_manager
+        handle._next_job_model_name = "events_daily"
+
+        mgr.execute(_DUMMY_SCRIPT)
+
+        handle.cancel_orphaned_jobs.assert_called_once_with("events_daily")
+
+    def test_no_cancellation_without_model_name(self, mock_manager):
+        mgr, handle = mock_manager
+        handle._next_job_model_name = None
+
+        mgr.execute(_DUMMY_SCRIPT)
+
+        handle.cancel_orphaned_jobs.assert_not_called()
+
+    def test_model_name_passed_to_submit_and_wait(self, mock_manager):
+        mgr, handle = mock_manager
+        handle._next_job_model_name = "events_daily"
+
+        mgr.execute(_DUMMY_SCRIPT)
+
+        call_kwargs = handle.submit_and_wait.call_args
+        assert call_kwargs.kwargs["model_name"] == "events_daily"
+
+    def test_model_name_none_passed_when_not_set(self, mock_manager):
+        mgr, handle = mock_manager
+        handle._next_job_model_name = None
+
+        mgr.execute(_DUMMY_SCRIPT)
+
+        call_kwargs = handle.submit_and_wait.call_args
+        assert call_kwargs.kwargs["model_name"] is None
+
+    def test_model_name_persists_across_calls(self, mock_manager):
+        """_next_job_model_name is NOT cleared after execute — it persists for
+        subsequent batches in the same materialization."""
+        mgr, handle = mock_manager
+        handle._next_job_model_name = "events_daily"
+
+        mgr.execute(_DUMMY_SCRIPT)
+
+        # Model name should still be set
+        assert handle._next_job_model_name == "events_daily"
+
+    def test_skipped_scripts_dont_trigger_cancellation(self, mock_manager):
+        mgr, handle = mock_manager
+        handle._next_job_model_name = "events_daily"
+
+        # Comment-only script is skipped
+        mgr.execute("-- no-op: skipped")
+
+        handle.cancel_orphaned_jobs.assert_not_called()
+        handle.submit_and_wait.assert_not_called()
+        # Model name should still be set
+        assert handle._next_job_model_name == "events_daily"
+
+
+class TestNextJobModelNameOnHandle:
+    """_next_job_model_name initialization and behavior."""
+
+    def test_defaults_to_none(self):
+        handle = _make_handle()
+        assert handle._next_job_model_name is None
+
+    def test_can_be_set_and_read(self):
+        handle = _make_handle()
+        handle._next_job_model_name = "my_model"
+        assert handle._next_job_model_name == "my_model"

--- a/tests/unit/test_job_naming.py
+++ b/tests/unit/test_job_naming.py
@@ -59,7 +59,7 @@ class TestExecuteJobName:
         connection = MagicMock()
         connection.handle = handle
         connection.credentials = MagicMock(
-            au=100, priority=1, poll_interval_seconds=5, max_wait_seconds=60
+            au=100, priority=1, poll_interval_seconds=5, job_timeout_seconds=60
         )
         mgr.get_thread_connection.return_value = connection
         return mgr, handle
@@ -125,7 +125,7 @@ class TestExecuteJobName:
 
 
 class TestExecuteMaxWaitOverride:
-    """ScopeConnectionManager.execute() uses _next_job_max_wait when set."""
+    """ScopeConnectionManager.execute() uses _next_job_timeout_seconds when set."""
 
     @pytest.fixture
     def mock_manager(self):
@@ -141,21 +141,21 @@ class TestExecuteMaxWaitOverride:
 
         handle = MagicMock()
         handle._next_job_name = None
-        handle._next_job_max_wait = None
+        handle._next_job_timeout_seconds = None
         handle.submit_and_wait = MagicMock()
         handle.submit_and_wait.return_value = MagicMock(job_id="test-id", result="Succeeded")
 
         connection = MagicMock()
         connection.handle = handle
         connection.credentials = MagicMock(
-            au=100, priority=1, poll_interval_seconds=5, max_wait_seconds=3600
+            au=100, priority=1, poll_interval_seconds=5, job_timeout_seconds=3600
         )
         mgr.get_thread_connection.return_value = connection
         return mgr, handle
 
     def test_uses_override_when_set(self, mock_manager):
         mgr, handle = mock_manager
-        handle._next_job_max_wait = 7200
+        handle._next_job_timeout_seconds = 7200
 
         mgr.execute(_DUMMY_SCRIPT)
 
@@ -165,15 +165,15 @@ class TestExecuteMaxWaitOverride:
 
     def test_clears_override_after_use(self, mock_manager):
         mgr, handle = mock_manager
-        handle._next_job_max_wait = 7200
+        handle._next_job_timeout_seconds = 7200
 
         mgr.execute(_DUMMY_SCRIPT)
 
-        assert handle._next_job_max_wait is None
+        assert handle._next_job_timeout_seconds is None
 
     def test_falls_back_to_profile_default(self, mock_manager):
         mgr, handle = mock_manager
-        handle._next_job_max_wait = None
+        handle._next_job_timeout_seconds = None
 
         mgr.execute(_DUMMY_SCRIPT)
 
@@ -183,9 +183,9 @@ class TestExecuteMaxWaitOverride:
 
     def test_not_consumed_for_skipped_scripts(self, mock_manager):
         mgr, handle = mock_manager
-        handle._next_job_max_wait = 7200
+        handle._next_job_timeout_seconds = 7200
 
         mgr.execute("-- no-op: skipped")
 
         handle.submit_and_wait.assert_not_called()
-        assert handle._next_job_max_wait == 7200
+        assert handle._next_job_timeout_seconds == 7200


### PR DESCRIPTION
## Summary

This branch includes three sets of changes: robust orphan job cancellation for ADLA, general cleanup/fixes (including timeout config), and a performance optimization that caches ADLS Gen1 file listings during microbatch processing.

Closes #19, closes #20, closes #21

## Changes

### 1. Robust orphan job cancellation (`956f2ad`) — Closes #20

Adds pre-submission cancellation of orphan ADLA jobs for a model. Before submitting a new SCOPE job, the adapter now checks for and cancels any active ADLA jobs matching the model name — preventing resource waste from prior failed/abandoned runs.

**Files changed:**
- `dbt/adapters/scope/connections.py` — Job cancellation logic via ADLA REST API
- `dbt/adapters/scope/impl.py` — `set_next_job_model_name()` for orphan tracking
- `dbt/include/scope/macros/materializations/incremental.sql` — Register model name before job submission
- `dbt/include/scope/macros/materializations/table.sql` — Same for table materialization
- `tests/unit/test_job_lifecycle.py` — 454 lines of new tests for job lifecycle

### 2. Checkpoint / cleanup (`828dad2`) — Closes #19

General cleanup, README updates, credential/config fixes (including timeout config consolidation), and test adjustments.

**Files changed:**
- `README.md` — Documentation updates
- `dbt/adapters/scope/connections.py` — Minor fixes
- `dbt/adapters/scope/credentials.py` — Credential field fix
- `dbt/adapters/scope/impl.py` — Code cleanup
- Materialization macros, integration profiles, and test updates

### 3. Cache ADLS Gen1 file listings per model (`f35ba88`) — Closes #21

When a model fires microbatches, ADLS Gen1 files are now listed **once** and reused for all subsequent batch iterations. Previously, every iteration performed a full recursive directory walk (LIST) for both `discover_files()` and `update_checkpoint()`.

**Before**: `2 x N x R x P` LIST operations per model (N batches x R roots x P patterns)
**After**: `R x P` LIST operations per model (just the initial listing)

**Files changed:**
- `dbt/adapters/scope/adls_gen1_client.py` — Added `_file_cache` (list_files cache by root+pattern), `_enrichment_cache` (enrich_with_estimates cache per file path), `clear_file_cache()` to reset both
- `dbt/adapters/scope/impl.py` — `discover_files()` stores `_discovered_file_infos` (path to FileInfo); `update_checkpoint()` uses cache instead of re-listing; added `@available clear_file_discovery_cache()`
- `tests/unit/test_file_cache.py` — 11 new tests for cache hit/miss/clear and batch loop lifecycle

## Test Results

- **286 tests passing**, lint clean
- 12 files changed, +1035 / -84 lines