### PR TITLE
feat: Delta schema evolution (#35), transient job retry (#40), and eviction self-cancel fix (#39)

### DIFF
--- a/.github/scripts/imds_relay_router.py
+++ b/.github/scripts/imds_relay_router.py
@@ -1,14 +1,24 @@
 #!/usr/bin/env python3
 """IMDS Relay Router — proxies az login --identity token requests to Azure Relay."""
 
-import base64, hashlib, hmac, json, os, time, urllib.parse, urllib.request
-from http.server import BaseHTTPRequestHandler, HTTPServer
+import base64
+import hashlib
+import hmac
+import json
+import os
+import threading
+import time
+import urllib.parse
+import urllib.request
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 
 LISTEN_PORT = int(os.environ.get("IMDS_ROUTER_PORT", "8080"))
 RELAY_URL = os.environ.get("IMDS_RELAY_URL", "")
 RELAY_SENDER_KEY = os.environ.get("IMDS_RELAY_SENDER_KEY", "")
 RELAY_KEY_NAME = os.environ.get("IMDS_RELAY_KEY_NAME", "Send")
 IDENTITY_HEADER_VALUE = os.environ.get("IDENTITY_HEADER", "local-dev-secret")
+TOKEN_MAX_ATTEMPTS = int(os.environ.get("IMDS_TOKEN_MAX_ATTEMPTS", "3"))
+TOKEN_EXPIRY_SKEW_SEC = int(os.environ.get("IMDS_TOKEN_EXPIRY_SKEW_SEC", "300"))
 
 
 def _relay_sas_uri(url: str) -> str:
@@ -23,6 +33,51 @@ def _generate_sas_token(uri: str, key: str, key_name: str, expiry_seconds: int =
     sig = hmac.new(key.encode(), sts.encode(), hashlib.sha256).digest()
     sig_b64 = urllib.parse.quote(base64.b64encode(sig).decode(), safe="")
     return f"SharedAccessSignature sr={urllib.parse.quote(uri, safe='')}&sig={sig_b64}&se={expiry}&skn={key_name}"
+
+
+class TokenCache:
+    """Route-/scope-aware token cache.
+
+    Keyed by resource (+ client_id), so different scopes never share an entry. A
+    token within ``skew_sec`` of expiry is treated as stale so callers refetch
+    ahead of expiry rather than serving a token about to expire. This collapses
+    the many repeated ``az`` token requests (one per worker per scope) down to a
+    single upstream relay fetch per scope, which is the dominant defense against
+    intermittent relay failures.
+    """
+
+    def __init__(self, skew_sec, now=lambda: int(time.time())):
+        self._entries = {}
+        self._skew_sec = skew_sec
+        self._now = now
+        self._lock = threading.Lock()
+
+    def is_fresh(self, entry):
+        return entry["expires_on"] - self._now() > self._skew_sec
+
+    def get(self, key):
+        with self._lock:
+            hit = self._entries.get(key)
+            if hit is None:
+                return None
+            if self.is_fresh(hit):
+                return hit
+            del self._entries[key]
+            return None
+
+    def set(self, key, entry):
+        with self._lock:
+            self._entries[key] = entry
+
+
+def _parse_expires_on(value):
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+_CACHE = TokenCache(TOKEN_EXPIRY_SKEW_SEC)
 
 
 class Handler(BaseHTTPRequestHandler):
@@ -50,25 +105,42 @@ class Handler(BaseHTTPRequestHandler):
         if not RELAY_URL or not RELAY_SENDER_KEY:
             return self._json(500, {"error": "IMDS_RELAY_URL or IMDS_RELAY_SENDER_KEY not set"})
 
-        try:
-            relay_uri = f"{RELAY_URL}?resource={urllib.parse.quote_plus(resource)}"
-            client_id = qs.get("client_id", [None])[0]
-            if client_id:
-                relay_uri += f"&client_id={urllib.parse.quote_plus(client_id)}"
+        relay_uri = f"{RELAY_URL}?resource={urllib.parse.quote_plus(resource)}"
+        client_id = qs.get("client_id", [None])[0]
+        if client_id:
+            relay_uri += f"&client_id={urllib.parse.quote_plus(client_id)}"
 
-            sas = _generate_sas_token(_relay_sas_uri(RELAY_URL), RELAY_SENDER_KEY, RELAY_KEY_NAME)
-            req = urllib.request.Request(relay_uri, headers={"ServiceBusAuthorization": sas})
-            with urllib.request.urlopen(req, timeout=30) as resp:
-                body = json.loads(resp.read().decode())
+        cache_key = resource if not client_id else f"{resource}|client_id={client_id}"
+        cached = _CACHE.get(cache_key)
+        if cached:
+            self.log_message("Cache hit: %s (expires_on=%s)", cache_key, cached["expires_on"])
+            return self._json(200, {"access_token": cached["access_token"], "expires_on": str(cached["expires_on"]), "resource": resource, "token_type": "Bearer"})
 
-            self._json(200, {"access_token": body.get("access_token", ""), "expires_on": str(body.get("expires_on", "")), "resource": resource, "token_type": "Bearer"})
-        except urllib.error.HTTPError as e:
-            detail = e.read().decode() if e.fp else ""
-            self.log_message("Relay error %s: %s", e.code, detail[:200])
-            self._json(502, {"error": f"Relay {e.code}", "detail": detail[:500]})
-        except Exception as e:
-            self.log_message("Error: %s", e)
-            self._json(500, {"error": str(e)})
+        last_error = "unknown error"
+        for attempt in range(1, TOKEN_MAX_ATTEMPTS + 1):
+            try:
+                sas = _generate_sas_token(_relay_sas_uri(RELAY_URL), RELAY_SENDER_KEY, RELAY_KEY_NAME)
+                req = urllib.request.Request(relay_uri, headers={"ServiceBusAuthorization": sas})
+                with urllib.request.urlopen(req, timeout=30) as resp:
+                    body = json.loads(resp.read().decode())
+                access_token = body.get("access_token", "")
+                if access_token:
+                    expires_on = _parse_expires_on(body.get("expires_on"))
+                    if expires_on is not None:
+                        _CACHE.set(cache_key, {"access_token": access_token, "expires_on": expires_on})
+                    return self._json(200, {"access_token": access_token, "expires_on": str(body.get("expires_on", "")), "resource": resource, "token_type": "Bearer"})
+                last_error = "relay returned empty access_token"
+            except urllib.error.HTTPError as e:
+                detail = e.read().decode() if e.fp else ""
+                last_error = f"Relay {e.code}: {detail[:200]}"
+            except Exception as e:
+                last_error = str(e)
+
+            self.log_message("Token attempt %d/%d failed: %s", attempt, TOKEN_MAX_ATTEMPTS, last_error)
+            if attempt < TOKEN_MAX_ATTEMPTS:
+                time.sleep(min(2**attempt, 10))
+
+        self._json(502, {"error": "Relay token request failed", "detail": last_error[:500]})
 
     def _json(self, status: int, body: dict):
         payload = json.dumps(body).encode()
@@ -80,6 +152,6 @@ class Handler(BaseHTTPRequestHandler):
 
 
 if __name__ == "__main__":
-    server = HTTPServer(("0.0.0.0", LISTEN_PORT), Handler)
+    server = ThreadingHTTPServer(("0.0.0.0", LISTEN_PORT), Handler)
     print(f"[imds-router] Listening on 0.0.0.0:{LISTEN_PORT}", flush=True)
     server.serve_forever()

--- a/.github/workflows/gci.yaml
+++ b/.github/workflows/gci.yaml
@@ -4,6 +4,10 @@ on:
   pull_request:
   workflow_dispatch:
 
+concurrency:
+  group: gci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 env:
   IS_GH_ACTION: "1"
   IMDS_ROUTER_PORT: "8080"
@@ -50,7 +54,15 @@ jobs:
       - name: "🔐 Az Login with Fake UAMI"
         run: |
           set -euo pipefail
-          az login --identity --client-id "$UAMI_CLIENT_ID" > /dev/null 2>&1
+          for attempt in $(seq 1 25); do
+            if az login --identity --client-id "$UAMI_CLIENT_ID" > /dev/null 2>&1; then
+              exit 0
+            fi
+            echo "az login attempt ${attempt}/25 failed; retrying in 1s" >&2
+            sleep 1
+          done
+          echo "az login still failing; final attempt (errors shown):" >&2
+          az login --identity --client-id "$UAMI_CLIENT_ID"
 
       - name: "⚙️ Bootstrap Dev Environment"
         run: |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,6 +46,15 @@
    gh auth login
    ```
 
+5. Install recommended developer tooling (optional):
+
+   ```bash
+   curl -fsSL https://gh.io/copilot-install | bash
+   $HOME/.local/bin/copilot --yolo
+   ```
+
+6. Take `.env.example` and fill out `.env`
+
 ## Quick start
 
 ```bash

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,8 +59,7 @@
 
 ```bash
 curl -LsSf https://astral.sh/uv/install.sh | sh  # one-time install for uv
-cp .env.example .env      # fill in your ADLA/storage values
-.scripts/run.sh all       # uv venv, sync, build, lint, unit-test, debug, integration-test
+.scripts/run.sh all                              # uv venv, sync, build, lint, unit-test, debug, integration-test
 ```
 
 ## Dev script

--- a/README.md
+++ b/README.md
@@ -304,7 +304,7 @@ WHERE edition == "Standard"
 | `source_compaction_interval` | `10`                                   | Every N batches, write a parquet snapshot of all source history                                                                                                                        |
 | `source_retention_files`     | `100`                                  | Max files in `_checkpoint/sources/` — oldest are deleted first                                                                                                                         |
 | `starting_timestamp`         | —                                      | ISO 8601 timestamp (e.g. `2026-01-01T00:00:00+00:00`); only process files modified after this time when no watermark exists                                                            |
-| `delta_table_columns`        | `[]`                                   | Delta table schema (CREATE TABLE). List of `{name, type}` dicts                                                                                                                        |
+| `delta_table_columns`        | `[]`                                   | Delta table schema (CREATE TABLE). List of `{name, type}` dicts. Adding a column triggers automatic [schema evolution](#schema-evolution)                                              |
 | `extract_columns`            | `[]`                                   | Source file columns (EXTRACT). List of `{name, type}` dicts                                                                                                                            |
 | `partition_by`               | —                                      | Single column name or list of columns for Delta table partitioning                                                                                                                     |
 | `scope_settings`             | `{}`                                   | Delta table properties passed to `ALTER TABLE SET TBLPROPERTIES` (e.g. compression, checkpoint intervals)                                                                              |
@@ -315,6 +315,24 @@ WHERE edition == "Standard"
 | `scope_feature_previews`     | `"EnableDeltaTableDynamicInsert:on"`   | Per-model SCOPE feature preview flags override                                                                                                                                         |
 
 `dbt retry` re-runs failed batches. `dbt run --full-refresh` resets the checkpoint and reprocesses all files.
+
+### Schema evolution
+
+Before building each SCOPE script, the adapter compares the model's `delta_table_columns`
+against the live Delta table schema (read with DuckDB, after confirming `_delta_log` exists
+on ADLS). The diff drives one of three outcomes:
+
+- **New column** in `delta_table_columns` that the table lacks → the adapter injects
+  `ALTER TABLE @target ADD COLUMN IF NOT EXISTS <name> <type>;` into the script so the table
+  evolves before the `INSERT`. Existing rows get `NULL` for the new column.
+- **Column removed** from `delta_table_columns` that the table still has → the run **fails**
+  with a `DbtRuntimeError` showing both schemas and the offending columns (dbt-scope never
+  drops columns).
+- **Column type changed** for an existing column → the run **fails** with a diff. (Type
+  comparison is equivalence-based, e.g. SCOPE `long` ≡ Delta `BIGINT`.)
+
+If the Delta table does not exist yet, no evolution happens — `CREATE TABLE` creates the full
+schema. This applies to both the `table` (full-refresh) and `incremental` materializations.
 
 ### Byte estimation for SSv5/v6 structured streams
 

--- a/README.md
+++ b/README.md
@@ -162,25 +162,30 @@ my_project:
 
 ### Profile reference
 
-| Field                     | Default                                    | Description                                                        |
-| ------------------------- | ------------------------------------------ | ------------------------------------------------------------------ |
-| `adla_account`            | —                                          | ADLA account name                                                  |
-| `storage_account`         | —                                          | ADLS Gen2 storage account name (also used as dbt `database`)       |
-| `container`               | —                                          | ADLS Gen2 container (also used as dbt `schema`)                    |
-| `delta_base_path`         | `"delta"`                                  | Base path under the container for Delta tables                     |
-| `adls_gen1_account`       | `""`                                       | ADLS Gen1 account for source file listing                          |
-| `au`                      | `100`                                      | Default ADLA Analytics Units (parallelism) per job                 |
-| `priority`                | `1`                                        | Default ADLA job priority                                          |
-| `poll_interval_seconds`   | `5`                                        | How often (seconds) to poll ADLA for job status                    |
-| `job_timeout_seconds`     | `36000`                                    | Max seconds to wait for a SCOPE job before timing out              |
-| `max_files_per_trigger`   | `50`                                       | Default max files per SCOPE job (overridable per-model)            |
-| `max_bytes_per_trigger`   | `10737418240000` (10 TB)                   | Default max estimated bytes per batch (overridable per-model)      |
-| `max_file_count_per_output_file_set` | `5000`                          | SCOPE `@@MaxFileCountPerOutputFileSet` (overridable per-model)     |
-| `cancel_jobs_on_shutdown` | `true`                                     | Cancel in-flight ADLA jobs on SIGINT/SIGTERM                       |
-| `wait_on_cancel_seconds`  | `30`                                       | Per-job wait for ADLA terminal state when cancelling on shutdown   |
-| `http_timeout_seconds`    | `30`                                       | HTTP request timeout for ADLA REST API calls                       |
-| `http_retries`            | `3`                                        | Number of HTTP retries for transient errors (429, 5xx)             |
-| `scope_feature_previews`  | `"EnableDeltaTableDynamicInsert:on"`       | SCOPE feature preview flags (overridable per-model)                |
+| Field                                | Default                              | Description                                                                                                        |
+| ------------------------------------ | ------------------------------------ | ------------------------------------------------------------------------------------------------------------------ |
+| `adla_account`                       | —                                    | ADLA account name                                                                                                  |
+| `storage_account`                    | —                                    | ADLS Gen2 storage account name (also used as dbt `database`)                                                       |
+| `container`                          | —                                    | ADLS Gen2 container (also used as dbt `schema`)                                                                    |
+| `delta_base_path`                    | `"delta"`                            | Base path under the container for Delta tables                                                                     |
+| `adls_gen1_account`                  | `""`                                 | ADLS Gen1 account for source file listing                                                                          |
+| `au`                                 | `100`                                | Default ADLA Analytics Units (parallelism) per job                                                                 |
+| `priority`                           | `1`                                  | Default ADLA job priority                                                                                          |
+| `poll_interval_seconds`              | `5`                                  | How often (seconds) to poll ADLA for job status                                                                    |
+| `job_timeout_seconds`                | `36000`                              | Max seconds to wait for a SCOPE job before timing out                                                              |
+| `max_files_per_trigger`              | `50`                                 | Default max files per SCOPE job (overridable per-model)                                                            |
+| `max_bytes_per_trigger`              | `10737418240000` (10 TB)             | Default max estimated bytes per batch (overridable per-model)                                                      |
+| `max_file_count_per_output_file_set` | `5000`                               | SCOPE `@@MaxFileCountPerOutputFileSet` (overridable per-model)                                                     |
+| `cancel_jobs_on_shutdown`            | `true`                               | Cancel in-flight ADLA jobs on SIGINT/SIGTERM                                                                       |
+| `wait_on_cancel_seconds`             | `30`                                 | Per-job wait for ADLA terminal state when cancelling on shutdown                                                   |
+| `http_timeout_seconds`               | `30`                                 | HTTP request timeout for ADLA REST API calls                                                                       |
+| `http_retries`                       | `3`                                  | Number of HTTP retries for transient errors (429, 5xx)                                                             |
+| `enable_job_retry`                   | `true`                               | Re-submit a SCOPE job when it fails with a known-transient error (see [Transient job retry](#transient-job-retry)) |
+| `job_retry_on_messages`              | `[]`                                 | Extra retry patterns (substring, or `re:` regex) merged with the built-in rules                                    |
+| `job_retry_max_attempts`             | `3`                                  | Total attempts (1 = no retry) for a transient job failure                                                          |
+| `job_retry_initial_wait_seconds`     | `30`                                 | Initial backoff before the first job re-submit                                                                     |
+| `job_retry_max_wait_seconds`         | `300`                                | Cap on the exponential job-retry backoff                                                                           |
+| `scope_feature_previews`             | `"EnableDeltaTableDynamicInsert:on"` | SCOPE feature preview flags (overridable per-model)                                                                |
 
 | dbt concept   | SCOPE concept                                                                   |
 | ------------- | ------------------------------------------------------------------------------- |
@@ -189,6 +194,52 @@ my_project:
 | `table`       | Full-refresh: `CREATE TABLE` + `INSERT INTO`                                    |
 | `incremental` | File-based append: discover → process → checkpoint, looped until all files done |
 | model SQL     | `SELECT` from `@data` (extracted SS rowset)                                     |
+
+### Transient job retry
+
+SCOPE jobs occasionally fail with transient infrastructure errors (e.g. a vertex
+that times out opening a DMS stream) or are cancelled by an external actor. The
+adapter re-submits the job when the terminal error message matches a known-transient
+rule, using a capped exponential backoff (`job_retry_initial_wait_seconds` →
+`job_retry_max_wait_seconds`) up to `job_retry_max_attempts`. A non-matching failure
+(e.g. a SCOPE compilation error) is **not** retried.
+
+Rules are a curated, growable RegEx data structure (`DEFAULT_JOB_RETRY_RULES` in
+`dbt/adapters/scope/message_retry.py`). The built-in seed set covers:
+
+- `Exception in VertexManager ... Failed to open stream ... Operation timed out`
+  (transient DMS stream-open timeout).
+- `Job cancelled by user ...` (cancelled by an external actor, e.g. another pipeline's
+  quota eviction).
+
+Add your own patterns via `job_retry_on_messages` (plain substring, or `re:`-prefixed
+regex) — they are merged with the built-ins. Set `enable_job_retry: false` to turn the
+layer off entirely.
+
+```yaml
+# profiles.yml
+my_project:
+  target: dev
+  outputs:
+    dev:
+      type: scope
+      # ... other settings ...
+      job_retry_on_messages:
+        - "Operation timed out"                        # plain substring (case-sensitive)
+        - "Vertex failed with"                         # plain substring
+        - "re:Failed to open stream .* timed out"      # regex (prefix with 're:')
+        - 're:E_\d{4} transient'                       # regex with escaped digits
+      # Optional tuning (defaults shown):
+      enable_job_retry: true
+      job_retry_max_attempts: 3
+      job_retry_initial_wait_seconds: 30
+      job_retry_max_wait_seconds: 300
+```
+
+**Self-cancel safety:** the quota-eviction layer (which cancels low-priority jobs when
+the workspace queue is saturated) never evicts a job belonging to the current dbt run —
+it skips any job in this run (`related.runId`) or any job this process is actively
+polling. So the adapter will not cancel its own in-flight work.
 
 ## Usage
 
@@ -295,7 +346,7 @@ WHERE edition == "Standard"
 
 | Config                       | Default                                | Description                                                                                                                                                                            |
 | ---------------------------- | -------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `delta_location`             | `""`                                   | ABFSS path to the Delta table (e.g. `abfss://ctr@acct.dfs.core.windows.net/delta/my_table`)                                                                                           |
+| `delta_location`             | `""`                                   | ABFSS path to the Delta table (e.g. `abfss://ctr@acct.dfs.core.windows.net/delta/my_table`)                                                                                            |
 | `source_roots`               | `[]`                                   | List of ADLS Gen1 root paths to list source files from                                                                                                                                 |
 | `source_patterns`            | `['.*\\.ss$']`                         | List of regexes; the adapter discovers files for each root × pattern combo                                                                                                             |
 | `max_files_per_trigger`      | from profile (`50`)                    | Max files per SCOPE job. Larger = fewer jobs; smaller = faster feedback                                                                                                                |
@@ -386,11 +437,11 @@ Add the `trigger` config to your model's `config()` block:
 
 #### Trigger options
 
-| Option       | Type   | Required                    | Description                                                     |
-| ------------ | ------ | --------------------------- | --------------------------------------------------------------- |
+| Option       | Type   | Required                      | Description                                                    |
+| ------------ | ------ | ----------------------------- | -------------------------------------------------------------- |
 | `type`       | string | No (default: `available_now`) | `available_now` or `processing_time`                           |
-| `interval`   | string | Yes (for `processing_time`)  | Sleep duration between cycles: `'10 seconds'`, `'30s'`, `'5m'` |
-| `max_cycles` | int    | No (default: infinite)       | Maximum number of cycles before exiting                         |
+| `interval`   | string | Yes (for `processing_time`)   | Sleep duration between cycles: `'10 seconds'`, `'30s'`, `'5m'` |
+| `max_cycles` | int    | No (default: infinite)        | Maximum number of cycles before exiting                        |
 
 #### Behavior
 

--- a/dbt/adapters/scope/connections.py
+++ b/dbt/adapters/scope/connections.py
@@ -191,6 +191,7 @@ class ScopeConnectionHandle:
         self._credential = build_credential(credentials)
         self._session = self._build_session(credentials.http_retries)
         self._message_retry_policy = MessageRetryPolicy.from_credentials(credentials)
+        self._job_retry_policy = MessageRetryPolicy.for_job_retry(credentials)
         self._quota_eviction_policy = QuotaEvictionPolicy.from_credentials(credentials)
         self._cached_token: str | None = None
         self._token_expires_at: float = 0
@@ -309,6 +310,24 @@ class ScopeConnectionHandle:
             url += f"&$filter={url_quote(filter_expr)}"
         resp = self._request("GET", url)
         return resp.get("value", [])
+
+    def is_self_job(self, job: dict[str, Any]) -> bool:
+        """Return ``True`` when *job* belongs to the current dbt run.
+
+        A job is considered "self" when either:
+
+        - its ``jobId`` is registered in the process-wide active-jobs registry
+          (we are actively polling it right now), or
+        - its ``related.runId`` matches this process's ``_run_id`` (it was
+          submitted by this dbt invocation, even if not currently being polled).
+        """
+        job_id = str(job.get("jobId") or "")
+        if job_id:
+            with _active_jobs_lock:
+                if job_id in _active_jobs:
+                    return True
+        related = job.get("related") or {}
+        return related.get("runId") == ScopeConnectionHandle._run_id
 
     def cancel_orphaned_jobs(self, model_name: str) -> list[str]:
         """Cancel active ADLA jobs for *previous* runs of ``model_name``.
@@ -610,15 +629,24 @@ class ScopeConnectionManager(BaseConnectionManager):
             if effective_model_name:
                 handle.cancel_orphaned_jobs(effective_model_name)
 
-            job = handle.submit_and_wait(
-                name=effective_name,
-                script=sql,
-                au=effective_au,
-                priority=effective_priority,
-                poll_interval=credentials.poll_interval_seconds,
-                max_wait=effective_max_wait,
-                model_name=effective_model_name,
-                wait_on_cancel_seconds=credentials.wait_on_cancel_seconds,
+            # Re-submit the whole job on a transient, regex-matched failure
+            # Non-matching failures propagate unchanged.
+            def _run_job() -> ADLAJob:
+                return handle.submit_and_wait(
+                    name=effective_name,
+                    script=sql,
+                    au=effective_au,
+                    priority=effective_priority,
+                    poll_interval=credentials.poll_interval_seconds,
+                    max_wait=effective_max_wait,
+                    model_name=effective_model_name,
+                    wait_on_cancel_seconds=credentials.wait_on_cancel_seconds,
+                )
+
+            job = retry_on_message(
+                _run_job,
+                policy=handle._job_retry_policy,
+                label=f"SCOPE job '{effective_name}'",
             )
 
         response = AdapterResponse(

--- a/dbt/adapters/scope/credentials.py
+++ b/dbt/adapters/scope/credentials.py
@@ -78,6 +78,12 @@ class ScopeCredentials(Credentials):
     initial_wait_on_error_seconds: float = 1.0
     max_wait_on_error_seconds: float = 30.0
 
+    enable_job_retry: bool = True
+    job_retry_on_messages: list[str] = field(default_factory=list)
+    job_retry_max_attempts: int = 3
+    job_retry_initial_wait_seconds: float = 30.0
+    job_retry_max_wait_seconds: float = 300.0
+
     enable_quota_eviction: bool = True
     quota_eviction_max_attempts: int = 25
     quota_eviction_cancel_num: int = 5
@@ -118,6 +124,11 @@ class ScopeCredentials(Credentials):
             "max_retries_on_error",
             "initial_wait_on_error_seconds",
             "max_wait_on_error_seconds",
+            "enable_job_retry",
+            "job_retry_on_messages",
+            "job_retry_max_attempts",
+            "job_retry_initial_wait_seconds",
+            "job_retry_max_wait_seconds",
             "enable_quota_eviction",
             "quota_eviction_max_attempts",
             "quota_eviction_cancel_num",
@@ -165,6 +176,30 @@ class ScopeCredentials(Credentials):
             if not isinstance(entry, str) or not entry:
                 raise DbtRuntimeError(
                     f"retry_on_error_messages entries must be non-empty strings; got {entry!r}"
+                )
+
+        if self.job_retry_max_attempts < 1:
+            raise DbtRuntimeError(
+                f"job_retry_max_attempts must be >= 1; got {self.job_retry_max_attempts}"
+            )
+        if self.job_retry_initial_wait_seconds <= 0:
+            raise DbtRuntimeError(
+                "job_retry_initial_wait_seconds must be > 0; "
+                f"got {self.job_retry_initial_wait_seconds}"
+            )
+        if self.job_retry_max_wait_seconds <= 0:
+            raise DbtRuntimeError(
+                f"job_retry_max_wait_seconds must be > 0; got {self.job_retry_max_wait_seconds}"
+            )
+        if self.job_retry_initial_wait_seconds > self.job_retry_max_wait_seconds:
+            raise DbtRuntimeError(
+                "job_retry_initial_wait_seconds must be <= job_retry_max_wait_seconds; "
+                f"got {self.job_retry_initial_wait_seconds} > {self.job_retry_max_wait_seconds}"
+            )
+        for entry in self.job_retry_on_messages:
+            if not isinstance(entry, str) or not entry:
+                raise DbtRuntimeError(
+                    f"job_retry_on_messages entries must be non-empty strings; got {entry!r}"
                 )
 
         if self.quota_eviction_max_attempts < 0:

--- a/dbt/adapters/scope/delta_lake.py
+++ b/dbt/adapters/scope/delta_lake.py
@@ -57,6 +57,163 @@ def _sql_identifier(value: str) -> str:
     return f'"{escaped}"'
 
 
+# ---------------------------------------------------------------------------
+# Delta Lake schema evolution
+# ---------------------------------------------------------------------------
+
+# Canonical equivalence between SCOPE type spellings (as written in a model's
+# ``delta_table_columns``) and the DuckDB type names surfaced by ``delta_scan``.
+# Both spellings map to a single token so a dbt ``long`` and a DuckDB ``BIGINT``
+# compare equal. SCOPE and DuckDB spellings do not collide, so one table works
+# for both sides.
+_CANONICAL_TYPES: dict[str, str] = {
+    # strings
+    "string": "STRING",
+    "varchar": "STRING",
+    "char": "STRING",
+    "text": "STRING",
+    # booleans
+    "bool": "BOOL",
+    "boolean": "BOOL",
+    # integers (width matters: SCOPE int == 32-bit, long == 64-bit)
+    "sbyte": "INT8",
+    "tinyint": "INT8",
+    "int8": "INT8",
+    "short": "INT16",
+    "smallint": "INT16",
+    "int16": "INT16",
+    "int": "INT32",
+    "integer": "INT32",
+    "int32": "INT32",
+    "long": "INT64",
+    "bigint": "INT64",
+    "int64": "INT64",
+    # floating point
+    "float": "FLOAT32",
+    "real": "FLOAT32",
+    "float4": "FLOAT32",
+    "double": "FLOAT64",
+    "float8": "FLOAT64",
+    # temporal
+    "datetime": "DATETIME",
+    "date": "DATE",
+    # binary
+    "byte[]": "BINARY",
+    "binary": "BINARY",
+    "varbinary": "BINARY",
+    "blob": "BINARY",
+    "bytea": "BINARY",
+}
+
+
+def canonical_type(raw: str | None) -> str | None:
+    """Normalize a SCOPE or DuckDB type name to a canonical token.
+
+    Returns ``None`` for unknown types so callers can stay lenient (a type we
+    cannot confidently normalize must not trigger a spurious mismatch failure).
+    """
+    if not raw:
+        return None
+    base = raw.strip().rstrip("?").strip().lower()
+    if base.startswith("timestamp"):
+        return "DATETIME"
+    if base.startswith(("decimal", "numeric")):
+        return "DECIMAL"
+    paren = base.find("(")
+    if paren != -1:
+        base = base[:paren].strip()
+    return _CANONICAL_TYPES.get(base)
+
+
+def _format_schema(columns: list[tuple[str, str]]) -> str:
+    """Render ``[(name, type), ...]`` as an indented, aligned block."""
+    if not columns:
+        return "    (empty)"
+    width = max(len(name) for name, _ in columns)
+    return "\n".join(f"    {name.ljust(width)}  {dtype}" for name, dtype in columns)
+
+
+def diff_schema_for_evolution(
+    dbt_columns: list[dict[str, str]],
+    existing_schema: dict[str, str],
+    *,
+    partition_columns: tuple[str, ...] = (),
+    location: str = "",
+) -> list[dict[str, str]]:
+    """Diff a model's declared columns against the live Delta table schema.
+
+    Args:
+        dbt_columns: ``[{"name": .., "type": ..}, ...]`` from ``delta_table_columns``
+            (``type`` is a SCOPE type spelling).
+        existing_schema: ``{column_name: duckdb_type}`` read from the Delta table.
+        partition_columns: partition column names — excluded from the diff because
+            they are declared in ``CREATE TABLE`` and cannot be ``ALTER ADD COLUMN``-ed.
+        location: Delta table location, for error messages only.
+
+    Returns:
+        The subset of ``dbt_columns`` that are absent from the Delta table and must
+        be added via ``ALTER TABLE ... ADD COLUMN``.
+
+    Raises:
+        DbtRuntimeError: when a column exists in the Delta table but not in the model
+            (dbt-scope never drops columns), or when a column's type changed.
+    """
+    ignore = {c.lower() for c in partition_columns}
+    existing_by_lower = {name.lower(): (name, dtype) for name, dtype in existing_schema.items()}
+    dbt_by_lower = {c["name"].lower(): c for c in dbt_columns}
+
+    to_add: list[dict[str, str]] = []
+    type_mismatches: list[str] = []
+
+    for lower, col in dbt_by_lower.items():
+        if lower in ignore:
+            continue
+        if lower not in existing_by_lower:
+            to_add.append(col)
+            continue
+        _, existing_type = existing_by_lower[lower]
+        dbt_canon = canonical_type(col["type"])
+        existing_canon = canonical_type(existing_type)
+        # Only flag a mismatch when both sides are confidently known and differ.
+        if dbt_canon is not None and existing_canon is not None and dbt_canon != existing_canon:
+            type_mismatches.append(
+                f"    {col['name']}: model declares '{col['type']}' "
+                f"but the Delta table has '{existing_type}'"
+            )
+
+    missing_in_dbt = [
+        orig
+        for lower, (orig, _dtype) in existing_by_lower.items()
+        if lower not in dbt_by_lower and lower not in ignore
+    ]
+
+    if missing_in_dbt or type_mismatches:
+        dbt_block = _format_schema([(c["name"], c["type"]) for c in dbt_columns])
+        delta_block = _format_schema(sorted(existing_schema.items()))
+        problems: list[str] = []
+        if missing_in_dbt:
+            problems.append(
+                "Columns present in the Delta table but MISSING from the model "
+                "(dbt-scope does not drop columns):\n    " + ", ".join(sorted(missing_in_dbt))
+            )
+        if type_mismatches:
+            problems.append(
+                "Columns whose type changed (dbt-scope cannot evolve column types):\n"
+                + "\n".join(type_mismatches)
+            )
+        raise DbtRuntimeError(
+            f"Delta table schema at '{location}' is incompatible with the dbt model.\n\n"
+            f"Model delta_table_columns:\n{dbt_block}\n\n"
+            f"Existing Delta table schema:\n{delta_block}\n\n"
+            + "\n\n".join(problems)
+            + "\n\nFix your dbt model's delta_table_columns to match the Delta table "
+            "(re-add the missing columns and/or revert the changed types), or migrate "
+            "the table out of band. Only ADDING new columns is supported automatically."
+        )
+
+    return to_add
+
+
 @dataclass(frozen=True)
 class AbfssLocation:
     """Structured representation of an ``abfss://`` path."""
@@ -274,6 +431,28 @@ class DeltaLakeClient(ABC):
             log.debug(f"get_columns({delta_location}) → None (error)")
             return None
 
+    def get_schema(self, delta_location: str) -> dict[str, str] | None:
+        """Return the Delta schema as ``{column_name: duckdb_type}``.
+
+        Returns ``None`` when the table is unreadable (does not exist, or the
+        Delta log cannot be parsed). Column order is preserved.
+        """
+        try:
+            escaped_location = _sql_literal(delta_location)
+            with self.connect() as conn:
+                column_description = conn.execute(
+                    f"SELECT * FROM delta_scan('{escaped_location}') LIMIT 0"
+                ).description
+            schema = {column[0]: str(column[1]) for column in column_description}
+            log.debug(f"get_schema({delta_location}) → {schema!s}")
+            return schema
+        except CredentialUnavailableError:
+            log.error(f"get_schema: credential acquisition exhausted for {delta_location}")
+            raise
+        except Exception:
+            log.debug(f"get_schema({delta_location}) → None (error)")
+            return None
+
     def validate_partition_column(self, delta_location: str, partition_col: str) -> None:
         """Raise when an existing Delta table lacks the expected partition column."""
         columns = self.get_columns(delta_location)
@@ -407,3 +586,41 @@ class DuckDbDeltaLakeClient(DeltaLakeClient):
         except Exception:
             log.warning(f"list_table_paths({delta_location}) failed")
             return []
+
+    def delta_log_exists(self, delta_location: str) -> bool:
+        """Return ``True`` if a ``_delta_log/*.json`` commit exists for the table.
+
+        Lists only the ``_delta_log/`` prefix (not the whole table) and exits on
+        the first JSON commit file, so it stays cheap on large tables.
+        """
+        parsed = AbfssLocation.parse(delta_location)
+        if parsed is None:
+            return False
+
+        def _exists() -> bool:
+            service = DataLakeServiceClient(
+                account_url=parsed.account_url,
+                credential=self._credential,
+            )
+            file_system = service.get_file_system_client(parsed.container)
+            prefix = f"{parsed.path.rstrip('/')}/_delta_log"
+            for path in file_system.get_paths(path=prefix, recursive=True):
+                if not getattr(path, "is_directory", False) and path.name.endswith(".json"):
+                    return True
+            return False
+
+        try:
+            result = retry_on_message(
+                _exists,
+                policy=self._message_retry_policy,
+                label=f"delta_lake.delta_log_exists {delta_location}",
+            )
+            log.debug(f"delta_log_exists({delta_location}) → {result}")
+            return result
+        except CredentialUnavailableError:
+            log.error(f"delta_log_exists: credential acquisition exhausted for {delta_location}")
+            raise
+        except Exception:
+            # A missing path raises (path not found) — treat as "does not exist".
+            log.debug(f"delta_log_exists({delta_location}) → False (not found or error)")
+            return False

--- a/dbt/adapters/scope/impl.py
+++ b/dbt/adapters/scope/impl.py
@@ -34,7 +34,12 @@ from dbt.adapters.scope.constants import (
     DEFAULT_WAIT_ON_CANCEL_SECONDS,
 )
 from dbt.adapters.scope.credentials import ScopeCredentials
-from dbt.adapters.scope.delta_lake import RetryPolicy, build_credential
+from dbt.adapters.scope.delta_lake import (
+    DuckDbDeltaLakeClient,
+    RetryPolicy,
+    build_credential,
+    diff_schema_for_evolution,
+)
 from dbt.adapters.scope.file_tracker import FileTracker
 from dbt.adapters.scope.message_retry import MessageRetryPolicy, retry_on_message
 from dbt.adapters.scope.relation import ScopeRelation
@@ -777,6 +782,66 @@ class ScopeAdapter(BaseAdapter):
         }
 
     @available
+    def compute_schema_evolution(
+        self,
+        delta_location: str,
+        delta_table_columns: list[dict[str, str]],
+        partition_by: str | list[str] | None = None,
+    ) -> list[dict[str, str]]:
+        """Return the columns to ``ALTER TABLE ... ADD COLUMN`` for schema evolution.
+
+        Called from the materialization macros before building the SCOPE script:
+
+          1. If no ``_delta_log`` exists under *delta_location* (new table), return
+             ``[]`` — ``CREATE TABLE`` will create the full schema.
+          2. Otherwise read the live Delta schema and diff it against
+             *delta_table_columns*. Columns present in the table but missing from the
+             model, or whose type changed, raise ``DbtRuntimeError``. New columns are
+             returned as ``[{"name": .., "type": ..}, ...]`` to be added.
+
+        Args:
+            delta_location: ``abfss://`` path to the Delta table.
+            delta_table_columns: the model's ``delta_table_columns`` config.
+            partition_by: partition column(s), excluded from the diff.
+        """
+        if not delta_location or not delta_table_columns:
+            return []
+
+        client = self._get_delta_client()
+
+        if not client.delta_log_exists(delta_location):
+            log.debug(f"compute_schema_evolution: no _delta_log at {delta_location} → new table")
+            return []
+
+        existing_schema = client.get_schema(delta_location)
+        if existing_schema is None:
+            raise DbtRuntimeError(
+                f"Delta table at '{delta_location}' has a _delta_log but its schema could "
+                f"not be read for schema-evolution checks. Verify the table is a valid Delta "
+                f"table and that credentials can read it."
+            )
+
+        if isinstance(partition_by, str):
+            partition_columns: tuple[str, ...] = (partition_by,)
+        elif partition_by:
+            partition_columns = tuple(partition_by)
+        else:
+            partition_columns = ()
+
+        to_add = diff_schema_for_evolution(
+            delta_table_columns,
+            existing_schema,
+            partition_columns=partition_columns,
+            location=delta_location,
+        )
+        if to_add:
+            log.info(
+                f"SCOPE: schema evolution for {delta_location} — adding "
+                f"{len(to_add)} column(s): {', '.join(c['name'] for c in to_add)}"
+            )
+        return to_add
+
+    @available
     def get_processing_time_timeout(self) -> int:
         """Return the default timeout (seconds) for processing_time models."""
         return DEFAULT_PROCESSING_TIME_TIMEOUT_SECONDS
@@ -946,3 +1011,13 @@ class ScopeAdapter(BaseAdapter):
                 checkpoint_manager=self._get_checkpoint_manager(),
             )
         return self._file_tracker
+
+    def _get_delta_client(self) -> DuckDbDeltaLakeClient:
+        """Return the DuckDB-backed Delta Lake client singleton."""
+        if not hasattr(self, "_delta_client"):
+            creds = self._credentials()
+            self._delta_client = DuckDbDeltaLakeClient(
+                credential=build_credential(creds),
+                message_retry_policy=MessageRetryPolicy.from_credentials(creds),
+            )
+        return self._delta_client

--- a/dbt/adapters/scope/message_retry.py
+++ b/dbt/adapters/scope/message_retry.py
@@ -36,6 +36,60 @@ _REGEX_PREFIX = "re:"
 
 
 @dataclass(frozen=True)
+class RetryRule:
+    """A single regex-based retry rule for transient SCOPE job failures.
+
+    ``DEFAULT_JOB_RETRY_RULES`` below is the curated, growable rule set. To add
+    coverage for a newly-observed transient error, append a ``RetryRule`` with a
+    conservative regex and a short description of why it is safe to retry.
+    """
+
+    name: str
+    pattern: str
+    description: str
+
+
+# Built-in retry rules for SCOPE *job* failures (re-submit the whole job when the
+# terminal error message matches). Keep patterns conservative — broad patterns
+# risk re-running a genuinely-failed job. Grow this tuple over time.
+DEFAULT_JOB_RETRY_RULES: tuple[RetryRule, ...] = (
+    RetryRule(
+        name="vertex_stream_open_timeout",
+        pattern=r"Exception in VertexManager.*Failed to open stream.*Operation timed out",
+        description=("Transient DMS/Cosmos stream-open timeout in a vertex."),
+    ),
+    RetryRule(
+        name="job_cancelled_by_user",
+        pattern=r"Job cancelled by user .*",
+        description=(
+            "Job cancelled by an external actor (e.g. another pipeline's quota "
+            "eviction). Our own run's jobs are excluded from eviction separately "
+        ),
+    ),
+)
+
+
+def _compile_patterns(raw_patterns: list[Any]) -> list[Any]:
+    """Compile a list of pattern entries into substrings / ``re.Pattern`` objects.
+
+    Entries prefixed with ``re:`` are compiled as regexes; all others are kept as
+    plain (case-sensitive) substrings. Raises ``ValueError`` on malformed entries.
+    """
+    compiled: list[Any] = []
+    for entry in raw_patterns:
+        if not isinstance(entry, str) or not entry:
+            raise ValueError(f"retry pattern entries must be non-empty strings; got {entry!r}")
+        if entry.startswith(_REGEX_PREFIX):
+            pattern_text = entry[len(_REGEX_PREFIX) :]
+            if not pattern_text:
+                raise ValueError(f"retry regex entry {entry!r} is empty after 're:'")
+            compiled.append(re.compile(pattern_text))
+        else:
+            compiled.append(entry)
+    return compiled
+
+
+@dataclass(frozen=True)
 class MessageRetryPolicy:
     """Exponential-backoff retry triggered by exception message patterns.
 
@@ -60,21 +114,7 @@ class MessageRetryPolicy:
     @classmethod
     def from_credentials(cls, credentials: Any) -> MessageRetryPolicy:
         raw_patterns = getattr(credentials, "retry_on_error_messages", None) or []
-        compiled: list[Any] = []
-        for entry in raw_patterns:
-            if not isinstance(entry, str) or not entry:
-                raise ValueError(
-                    f"retry_on_error_messages entries must be non-empty strings; got {entry!r}"
-                )
-            if entry.startswith(_REGEX_PREFIX):
-                pattern_text = entry[len(_REGEX_PREFIX) :]
-                if not pattern_text:
-                    raise ValueError(
-                        f"retry_on_error_messages regex entry {entry!r} is empty after 're:'"
-                    )
-                compiled.append(re.compile(pattern_text))
-            else:
-                compiled.append(entry)
+        compiled = _compile_patterns(raw_patterns)
 
         max_retries = int(getattr(credentials, "max_retries_on_error", 25))
         initial_wait = float(getattr(credentials, "initial_wait_on_error_seconds", 1.0))
@@ -95,6 +135,51 @@ class MessageRetryPolicy:
         return cls(
             patterns=tuple(compiled),
             max_retries=max_retries,
+            initial_wait_seconds=initial_wait,
+            max_wait_seconds=max_wait,
+        )
+
+    @classmethod
+    def for_job_retry(cls, credentials: Any) -> MessageRetryPolicy:
+        """Build the policy that re-submits a SCOPE *job* on a transient failure.
+
+        Combines the built-in ``DEFAULT_JOB_RETRY_RULES`` with any user-supplied
+        ``job_retry_on_messages`` (same ``re:`` / substring syntax as
+        ``retry_on_error_messages``). Returns a disabled policy when
+        ``enable_job_retry`` is false so callers run the job exactly once.
+
+        Config (all optional, with defaults):
+          ``enable_job_retry`` (True), ``job_retry_on_messages`` ([]),
+          ``job_retry_max_attempts`` (3 total attempts),
+          ``job_retry_initial_wait_seconds`` (30), ``job_retry_max_wait_seconds`` (300).
+        """
+        if not bool(getattr(credentials, "enable_job_retry", True)):
+            return cls.disabled()
+
+        user_patterns = getattr(credentials, "job_retry_on_messages", None) or []
+        compiled = _compile_patterns(user_patterns)
+        compiled.extend(re.compile(rule.pattern) for rule in DEFAULT_JOB_RETRY_RULES)
+
+        max_attempts = int(getattr(credentials, "job_retry_max_attempts", 3))
+        initial_wait = float(getattr(credentials, "job_retry_initial_wait_seconds", 30.0))
+        max_wait = float(getattr(credentials, "job_retry_max_wait_seconds", 300.0))
+
+        if max_attempts < 1:
+            raise ValueError(f"job_retry_max_attempts must be >= 1; got {max_attempts}")
+        if initial_wait <= 0:
+            raise ValueError(f"job_retry_initial_wait_seconds must be > 0; got {initial_wait}")
+        if max_wait <= 0:
+            raise ValueError(f"job_retry_max_wait_seconds must be > 0; got {max_wait}")
+        if initial_wait > max_wait:
+            raise ValueError(
+                "job_retry_initial_wait_seconds must be <= job_retry_max_wait_seconds; "
+                f"got {initial_wait} > {max_wait}"
+            )
+
+        # MessageRetryPolicy.max_retries == additional attempts after the first.
+        return cls(
+            patterns=tuple(compiled),
+            max_retries=max_attempts - 1,
             initial_wait_seconds=initial_wait,
             max_wait_seconds=max_wait,
         )

--- a/dbt/adapters/scope/quota_eviction.py
+++ b/dbt/adapters/scope/quota_eviction.py
@@ -92,11 +92,16 @@ class EvictionContext(Protocol):
     ``cancel_job_async`` MUST be fire-and-forget — it must NOT block waiting
     for the job to reach a terminal state. Blocking would multiply the
     recovery time by the number of victims.
+
+    ``is_self_job`` lets the eviction layer skip jobs that belong to the
+    current dbt run (so we never cancel our own in-flight work — issue #39).
     """
 
     def list_jobs(self, filter_expr: str | None = None, top: int = 100) -> list[dict[str, Any]]: ...
 
     def cancel_job_async(self, job_id: str) -> None: ...
+
+    def is_self_job(self, job: dict[str, Any]) -> bool: ...
 
 
 def is_quota_error(exc: BaseException) -> bool:
@@ -186,6 +191,13 @@ def _gather_and_cancel(ctx: EvictionContext, policy: QuotaEvictionPolicy) -> lis
     except Exception as exc:
         log.warning(f"Quota eviction: list_jobs failed ({exc}); cannot pick victims.")
         return []
+
+    # Never evict jobs belonging to the current dbt run.
+    total = len(jobs)
+    jobs = [job for job in jobs if not ctx.is_self_job(job)]
+    skipped = total - len(jobs)
+    if skipped:
+        log.debug(f"Quota eviction: excluded {skipped} self-owned job(s) from eviction.")
 
     victims = select_victims(jobs, policy.cancel_num)
     if not victims:

--- a/dbt/adapters/scope/script_builder.py
+++ b/dbt/adapters/scope/script_builder.py
@@ -352,7 +352,7 @@ def _model_transform_and_insert(model_sql: str, delta_columns: list[ColumnDef]) 
     parts.append(f"    {sql};")
     parts.append("")
     col_list = ", ".join(c.name for c in delta_columns)
-    parts.append("INSERT INTO @target")
+    parts.append(f"INSERT INTO @target ({col_list})")
     parts.append(f"SELECT {col_list} FROM @batch_data;")
 
     return "\n".join(parts)

--- a/dbt/include/scope/macros/materializations/incremental.sql
+++ b/dbt/include/scope/macros/materializations/incremental.sql
@@ -102,6 +102,8 @@
         {%- endcall -%}
     {%- else -%}
         {%- set total_batches = adapter.get_total_batches() -%}
+        {# -- Compute schema evolution once against the live Delta table -- #}
+        {%- set evolve_columns = adapter.compute_schema_evolution(delta_location, delta_table_columns, partition_by) -%}
         {%- for _ in range(loop_cap) -%}
             {%- if not ns.keep_running -%}
                 {# Shutdown or max_cycles reached — exit loop #}
@@ -146,7 +148,8 @@
                     is_full_refresh=is_first_full_refresh_batch,
                     is_incremental=(not is_first_full_refresh_batch),
                     delta_lake_commit_condition=delta_lake_commit_condition,
-                    max_file_count_per_output_file_set=max_file_count_per_output_file_set
+                    max_file_count_per_output_file_set=max_file_count_per_output_file_set,
+                    evolve_columns=evolve_columns
                 ) -%}
 
                 {%- set mode_label = "full-refresh" if full_refresh_mode else "incremental" -%}

--- a/dbt/include/scope/macros/materializations/table.sql
+++ b/dbt/include/scope/macros/materializations/table.sql
@@ -60,6 +60,8 @@
         {%- endcall -%}
     {%- else -%}
         {%- set total_batches = adapter.get_total_batches() -%}
+        {# -- Compute schema evolution once against the live Delta table -- #}
+        {%- set evolve_columns = adapter.compute_schema_evolution(delta_location, delta_table_columns, partition_by) -%}
         {%- for _ in range(1000) -%}
             {%- if ns.file_batch | length == 0 -%}
                 {# Break out of loop #}
@@ -79,7 +81,8 @@
                     ns.file_batch,
                     is_full_refresh=(ns.batch_num == 1),
                     delta_lake_commit_condition=delta_lake_commit_condition,
-                    max_file_count_per_output_file_set=max_file_count_per_output_file_set
+                    max_file_count_per_output_file_set=max_file_count_per_output_file_set,
+                    evolve_columns=evolve_columns
                 ) -%}
 
                 {{ log("SCOPE: full-refresh " ~ identifier ~ " batch " ~ ns.batch_num ~ " of " ~ total_batches ~ " (" ~ ns.file_batch | length ~ " files)", info=True) }}
@@ -125,7 +128,8 @@
     is_full_refresh=false,
     is_incremental=false,
     delta_lake_commit_condition="FailIfFileConflict",
-    max_file_count_per_output_file_set=5000
+    max_file_count_per_output_file_set=5000,
+    evolve_columns=[]
 ) %}
 {# -- Normalize partition_by to a list -- #}
 {%- set partition_cols = partition_by if partition_by is iterable and partition_by is not string else ([partition_by] if partition_by else []) -%}
@@ -162,6 +166,13 @@ ALTER TABLE @target SET TBLPROPERTIES (
     "{{ key }}" = {{ scope__quote_property(value) }}{{ "," if not loop.last }}
 {%- endfor %}
 );
+{%- endif %}
+
+{# -- Schema evolution: ADD COLUMN for new columns on an existing Delta table -- #}
+{%- if evolve_columns %}
+{%- for col in evolve_columns %}
+ALTER TABLE @target ADD COLUMN IF NOT EXISTS {{ col.name }} {{ col.type }};
+{%- endfor %}
 {%- endif %}
 
 {# -- DELETE existing data for full-refresh idempotency -- #}

--- a/dbt/include/scope/macros/materializations/table.sql
+++ b/dbt/include/scope/macros/materializations/table.sql
@@ -208,7 +208,7 @@ DELETE FROM @target_rw WHERE true;
 @batch_data =
     {{ model_sql }};
 
-INSERT INTO @target
+INSERT INTO @target ({{ delta_table_columns | map(attribute='name') | join(', ') }})
 SELECT {{ delta_table_columns | map(attribute='name') | join(', ') }} FROM @batch_data;
 
 {% endmacro %}

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -172,9 +172,13 @@ def run_dbt(
     print(f"    Logs: {log_dir}")
 
     summary_file = log_dir / "result_summary.txt"
-    summary_file.write_text(
-        f"command: dbt {' '.join(args)}\nsuccess: {result.success}\nresult: {result.result}\n"
-    )
+    try:
+        log_dir.mkdir(parents=True, exist_ok=True)
+        summary_file.write_text(
+            f"command: dbt {' '.join(args)}\nsuccess: {result.success}\nresult: {result.result}\n"
+        )
+    except OSError as exc:
+        log.warning("Could not write result summary to %s: %s", summary_file, exc)
 
     return result
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -111,6 +111,21 @@ def append_scenario() -> ScenarioConfig:
     return scenario
 
 
+@pytest.fixture(scope="session")
+def evolve_scenario() -> ScenarioConfig:
+    """Scenario: Delta Lake schema evolution -- dedicated stream so v1 then v2 stays isolated.
+
+    Uses its own SS stream + Delta path so no other test's datagen advances this
+    table's watermark before the v2 (new-column) run.
+    """
+    scenario = _build_scenario("schema_evolve")
+    adla = _env("SCOPE_ADLA_ACCOUNT")
+
+    log.info("Generating historical SS files for schema-evolution scenario")
+    submit_datagen_job(scenario.historical, adla_account=adla, au=5)
+    return scenario
+
+
 # -- dbt runner ---------------------------------------------------------------
 
 
@@ -198,6 +213,11 @@ def verify_delta(delta_path: str) -> dict:
 def query_delta_with_duckdb(query: str) -> list[tuple]:
     """Execute a read-only DuckDB query with Delta + Azure extensions preloaded."""
     return _delta_client().fetchall(query)
+
+
+def delta_columns(delta_path: str) -> list[str] | None:
+    """Return the Delta table's column names (or None if unreadable)."""
+    return _delta_client().get_columns(delta_path)
 
 
 def verify_delta_with_duckdb(

--- a/tests/integration/dbt_project/models/evolve_v1.sql
+++ b/tests/integration/dbt_project/models/evolve_v1.sql
@@ -1,0 +1,39 @@
+{{
+    config(
+        materialized='incremental',
+        incremental_strategy='append',
+        partition_by='event_year_date',
+        delta_location=var('delta_location_evolve'),
+        job_tag=var('job_tag', none),
+        source_roots=var('source_roots'),
+        source_patterns=var('source_patterns', ['.*\\.ss$']),
+        max_files_per_trigger=var('max_files_per_trigger', 500),
+        starting_timestamp='1900-01-01T00:00:00+00:00',
+        safety_buffer_seconds=0,
+        source_compaction_interval=1,
+        source_retention_files=100,
+        au=4,
+        priority=1,
+        delta_table_columns=[
+            {'name': 'logical_server_name', 'type': 'string'},
+            {'name': 'edition', 'type': 'string'},
+            {'name': 'max_size_bytes', 'type': 'long'},
+            {'name': 'source_file_uri', 'type': 'string'},
+            {'name': 'event_year_date', 'type': 'string'}
+        ],
+        extract_columns=[
+            {'name': 'logical_server_name', 'type': 'string'},
+            {'name': 'edition', 'type': 'string'},
+            {'name': 'max_size_bytes', 'type': 'long'},
+            {'name': 'source_file_uri', 'type': 'string'}
+        ]
+    )
+}}
+
+SELECT
+    logical_server_name,
+    edition,
+    max_size_bytes,
+    source_file_uri,
+    DateTime.UtcNow.ToString("yyyyMMdd") AS event_year_date
+FROM @data

--- a/tests/integration/dbt_project/models/evolve_v2.sql
+++ b/tests/integration/dbt_project/models/evolve_v2.sql
@@ -1,0 +1,42 @@
+{{
+    config(
+        materialized='incremental',
+        incremental_strategy='append',
+        partition_by='event_year_date',
+        delta_location=var('delta_location_evolve'),
+        job_tag=var('job_tag', none),
+        source_roots=var('source_roots'),
+        source_patterns=var('source_patterns', ['.*\\.ss$']),
+        max_files_per_trigger=var('max_files_per_trigger', 500),
+        starting_timestamp='1900-01-01T00:00:00+00:00',
+        safety_buffer_seconds=0,
+        source_compaction_interval=1,
+        source_retention_files=100,
+        au=4,
+        priority=1,
+        delta_table_columns=[
+            {'name': 'logical_server_name', 'type': 'string'},
+            {'name': 'edition', 'type': 'string'},
+            {'name': 'max_size_bytes', 'type': 'long'},
+            {'name': 'source_file_uri', 'type': 'string'},
+            {'name': 'region_name', 'type': 'string'},
+            {'name': 'event_year_date', 'type': 'string'}
+        ],
+        extract_columns=[
+            {'name': 'logical_server_name', 'type': 'string'},
+            {'name': 'edition', 'type': 'string'},
+            {'name': 'max_size_bytes', 'type': 'long'},
+            {'name': 'source_file_uri', 'type': 'string'},
+            {'name': 'region_name', 'type': 'string'}
+        ]
+    )
+}}
+
+SELECT
+    logical_server_name,
+    edition,
+    max_size_bytes,
+    source_file_uri,
+    region_name,
+    DateTime.UtcNow.ToString("yyyyMMdd") AS event_year_date
+FROM @data

--- a/tests/integration/test_dbt_scope.py
+++ b/tests/integration/test_dbt_scope.py
@@ -299,10 +299,21 @@ class TestSchemaEvolution:
             f"region_name must be present after v2 schema evolution, got {cols_after}"
         )
 
-        non_null = query_delta_with_duckdb(
-            f"SELECT COUNT(*) FROM delta_scan('{delta_loc}') WHERE region_name IS NOT NULL"
+        region_rows = query_delta_with_duckdb(
+            f"SELECT DISTINCT region_name FROM delta_scan('{delta_loc}') "
+            f"WHERE region_name IS NOT NULL ORDER BY region_name"
         )
-        assert non_null[0][0] > 0, "region_name should be populated from the v2 SS batch"
+        region_values = {r[0] for r in region_rows}
+        assert region_values, "region_name should be populated from the v2 SS batch"
+        expected_regions = {r["region_name"] for r in dataset_to_records(evolve_scenario.new_data)}
+        assert region_values <= expected_regions, (
+            f"region_name holds unexpected values {sorted(region_values)}; "
+            f"expected a subset of {sorted(expected_regions)}. "
+            f"This indicates a positional INSERT column mismatch after schema evolution."
+        )
+        assert not any(str(v).isdigit() and len(str(v)) == 8 for v in region_values), (
+            f"region_name contains date-like values {sorted(region_values)} — column shift detected"
+        )
 
         after_info = verify_delta_with_duckdb(delta_loc)
         assert after_info["total_rows"] > before_info["total_rows"], (
@@ -311,10 +322,10 @@ class TestSchemaEvolution:
 
         log.info(
             "Schema evolution passed: cols %d->%d (region_name added), rows %d->%d, "
-            "region_name non-null=%d",
+            "region_name values=%s",
             len(cols_before),
             len(cols_after),
             before_info["total_rows"],
             after_info["total_rows"],
-            non_null[0][0],
+            sorted(region_values),
         )

--- a/tests/integration/test_dbt_scope.py
+++ b/tests/integration/test_dbt_scope.py
@@ -18,6 +18,7 @@ import pytest
 from conftest import (
     _PREFIX,
     ScenarioConfig,
+    delta_columns,
     list_source_files,
     query_delta_with_duckdb,
     read_batch_source,
@@ -34,6 +35,7 @@ def _dbt_vars(scenario: ScenarioConfig) -> dict:
     return {
         "delta_location": scenario.delta_location,
         "delta_location_filtered": f"{scenario.delta_location}_filtered",
+        "delta_location_evolve": f"{scenario.delta_location}_evolve",
         "source_roots": [scenario.historical.ss_base_path],
         "source_patterns": [r".*\.ss$"],
         "max_files_per_trigger": 500,
@@ -239,3 +241,80 @@ class TestFilteredEdition:
 
         wm = read_watermark(delta_filtered)
         assert wm is not None
+
+
+# ---------------------------------------------------------------------------
+# Schema evolution: ADD COLUMN on an existing Delta table (2 SCOPE jobs + 1 datagen)
+# ---------------------------------------------------------------------------
+
+
+class TestSchemaEvolution:
+    @pytest.mark.timeout(3600)
+    def test_add_column_evolves_existing_delta_table(
+        self, evolve_scenario: ScenarioConfig, request: pytest.FixtureRequest
+    ):
+        """Schema evolution end-to-end:
+        0. Run evolve_v1 (schema WITHOUT region_name) -> creates Delta table.
+        1. Generate new SS data so v2 has unprocessed files.
+        2. Run evolve_v2 (schema WITH region_name) -> ALTER ADD COLUMN + insert.
+        3. Assert region_name exists in the Delta table and is populated from SS.
+        """
+        vars_ = _dbt_vars(evolve_scenario)
+        delta_loc = vars_["delta_location_evolve"]
+        adla_account = os.environ.get("SCOPE_ADLA_ACCOUNT", "")
+        test_name = _test_id(request)
+
+        # Step 0: initial run with the v1 schema (no region_name)
+        result = run_dbt(
+            ["run", "--select", "evolve_v1"],
+            extra_vars=vars_,
+            test_name=f"{test_name}_v1",
+        )
+        assert result.success, f"evolve_v1 run failed: {result.result}"
+
+        cols_before = delta_columns(delta_loc)
+        assert cols_before is not None, "Delta table should be readable after v1"
+        assert "region_name" not in cols_before, (
+            f"region_name must be absent after v1, got {cols_before}"
+        )
+
+        before_info = verify_delta_with_duckdb(delta_loc)
+        assert before_info["total_rows"] > 0, "v1 should have inserted rows"
+
+        # Step 1: generate new SS data (later dates) so v2 has files to process
+        submit_datagen_job(evolve_scenario.new_data, adla_account=adla_account, au=5)
+
+        # Step 2: run v2 with the new column -> schema evolves, then inserts
+        result = run_dbt(
+            ["run", "--select", "evolve_v2"],
+            extra_vars=vars_,
+            test_name=f"{test_name}_v2",
+        )
+        assert result.success, f"evolve_v2 run failed: {result.result}"
+
+        # Step 3: the new column is now present and carries data from the SS batch
+        cols_after = delta_columns(delta_loc)
+        assert cols_after is not None
+        assert "region_name" in cols_after, (
+            f"region_name must be present after v2 schema evolution, got {cols_after}"
+        )
+
+        non_null = query_delta_with_duckdb(
+            f"SELECT COUNT(*) FROM delta_scan('{delta_loc}') WHERE region_name IS NOT NULL"
+        )
+        assert non_null[0][0] > 0, "region_name should be populated from the v2 SS batch"
+
+        after_info = verify_delta_with_duckdb(delta_loc)
+        assert after_info["total_rows"] > before_info["total_rows"], (
+            "v2 should have inserted additional rows"
+        )
+
+        log.info(
+            "Schema evolution passed: cols %d->%d (region_name added), rows %d->%d, "
+            "region_name non-null=%d",
+            len(cols_before),
+            len(cols_after),
+            before_info["total_rows"],
+            after_info["total_rows"],
+            non_null[0][0],
+        )

--- a/tests/unit/test_credentials.py
+++ b/tests/unit/test_credentials.py
@@ -181,6 +181,65 @@ class TestMessageRetryFields:
         assert "max_wait_on_error_seconds" in keys
 
 
+class TestJobRetryFields:
+    def test_defaults(self):
+        creds = ScopeCredentials(adla_account="x", **_BASE_KWARGS)
+        assert creds.enable_job_retry is True
+        assert creds.job_retry_on_messages == []
+        assert creds.job_retry_max_attempts == 3
+        assert creds.job_retry_initial_wait_seconds == 30.0
+        assert creds.job_retry_max_wait_seconds == 300.0
+
+    def test_custom_values_accepted(self):
+        creds = ScopeCredentials(
+            adla_account="x",
+            enable_job_retry=False,
+            job_retry_on_messages=["re:Operation timed out", "Flaky"],
+            job_retry_max_attempts=5,
+            job_retry_initial_wait_seconds=10.0,
+            job_retry_max_wait_seconds=120.0,
+            **_BASE_KWARGS,
+        )
+        assert creds.enable_job_retry is False
+        assert creds.job_retry_on_messages == ["re:Operation timed out", "Flaky"]
+        assert creds.job_retry_max_attempts == 5
+        assert creds.job_retry_initial_wait_seconds == 10.0
+        assert creds.job_retry_max_wait_seconds == 120.0
+
+    def test_zero_attempts_rejected(self):
+        with pytest.raises(DbtRuntimeError, match="job_retry_max_attempts must be >= 1"):
+            ScopeCredentials(adla_account="x", job_retry_max_attempts=0, **_BASE_KWARGS)
+
+    def test_non_positive_initial_wait_rejected(self):
+        with pytest.raises(DbtRuntimeError, match="job_retry_initial_wait_seconds must be > 0"):
+            ScopeCredentials(adla_account="x", job_retry_initial_wait_seconds=0, **_BASE_KWARGS)
+
+    def test_non_positive_max_wait_rejected(self):
+        with pytest.raises(DbtRuntimeError, match="job_retry_max_wait_seconds must be > 0"):
+            ScopeCredentials(adla_account="x", job_retry_max_wait_seconds=0, **_BASE_KWARGS)
+
+    def test_initial_greater_than_max_rejected(self):
+        with pytest.raises(DbtRuntimeError, match="must be <= job_retry_max_wait_seconds"):
+            ScopeCredentials(
+                adla_account="x",
+                job_retry_initial_wait_seconds=300,
+                job_retry_max_wait_seconds=30,
+                **_BASE_KWARGS,
+            )
+
+    def test_empty_pattern_string_rejected(self):
+        with pytest.raises(DbtRuntimeError, match="non-empty strings"):
+            ScopeCredentials(adla_account="x", job_retry_on_messages=[""], **_BASE_KWARGS)
+
+    def test_job_retry_fields_in_connection_keys(self):
+        keys = ScopeCredentials(adla_account="x", **_BASE_KWARGS)._connection_keys()
+        assert "enable_job_retry" in keys
+        assert "job_retry_on_messages" in keys
+        assert "job_retry_max_attempts" in keys
+        assert "job_retry_initial_wait_seconds" in keys
+        assert "job_retry_max_wait_seconds" in keys
+
+
 class TestQuotaEvictionFields:
     def test_defaults(self):
         creds = ScopeCredentials(adla_account="x", **_BASE_KWARGS)

--- a/tests/unit/test_delta_introspection.py
+++ b/tests/unit/test_delta_introspection.py
@@ -8,7 +8,12 @@ from unittest.mock import MagicMock, patch
 import pytest
 from dbt_common.exceptions import DbtRuntimeError
 
-from dbt.adapters.scope.delta_lake import DuckDbDeltaLakeClient, parse_abfss
+from dbt.adapters.scope.delta_lake import (
+    DuckDbDeltaLakeClient,
+    canonical_type,
+    diff_schema_for_evolution,
+    parse_abfss,
+)
 
 DELTA_LOC = "abfss://ctr@acct.dfs.core.windows.net/delta/my_table"
 
@@ -181,3 +186,155 @@ class TestDeltaLogFiles:
     def test_returns_zero_for_invalid_path(self):
         client, _ = make_client()
         assert client.count_delta_log_files("https://not-abfss.com/foo") == 0
+
+
+# -- delta_log_exists -----------------------------------------------------
+
+
+class TestDeltaLogExists:
+    @patch("dbt.adapters.scope.delta_lake.DataLakeServiceClient")
+    def test_true_when_json_commit_present(self, mock_service_client):
+        client, _ = make_client()
+        mock_file_system = MagicMock()
+        mock_file_system.get_paths.return_value = [
+            SimpleNamespace(
+                name="delta/my_table/_delta_log/00000000000000000000.json", is_directory=False
+            ),
+        ]
+        mock_service_client.return_value.get_file_system_client.return_value = mock_file_system
+        assert client.delta_log_exists(DELTA_LOC) is True
+
+    @patch("dbt.adapters.scope.delta_lake.DataLakeServiceClient")
+    def test_false_when_only_non_json(self, mock_service_client):
+        client, _ = make_client()
+        mock_file_system = MagicMock()
+        mock_file_system.get_paths.return_value = [
+            SimpleNamespace(name="delta/my_table/_delta_log/_last_checkpoint", is_directory=False),
+        ]
+        mock_service_client.return_value.get_file_system_client.return_value = mock_file_system
+        assert client.delta_log_exists(DELTA_LOC) is False
+
+    @patch("dbt.adapters.scope.delta_lake.DataLakeServiceClient")
+    def test_false_when_listing_raises(self, mock_service_client):
+        client, _ = make_client()
+        mock_service_client.return_value.get_file_system_client.side_effect = Exception("404")
+        assert client.delta_log_exists(DELTA_LOC) is False
+
+    def test_false_for_invalid_path(self):
+        client, _ = make_client()
+        assert client.delta_log_exists("https://not-abfss.com/foo") is False
+
+
+# -- get_schema -----------------------------------------------------------
+
+
+class TestGetSchema:
+    def test_returns_name_to_type_mapping(self):
+        client, mock_conn = make_client()
+        mock_conn.execute.return_value.description = [
+            ("a", "VARCHAR"),
+            ("b", "BIGINT"),
+            ("ts", "TIMESTAMP"),
+        ]
+        assert client.get_schema(DELTA_LOC) == {"a": "VARCHAR", "b": "BIGINT", "ts": "TIMESTAMP"}
+        mock_conn.close.assert_called_once()
+
+    def test_returns_none_on_error(self):
+        client, mock_conn = make_client()
+        mock_conn.execute.side_effect = [None, None, Exception("table not found")]
+        assert client.get_schema(DELTA_LOC) is None
+        mock_conn.close.assert_called_once()
+
+
+# -- canonical_type -------------------------------------------------------
+
+
+class TestCanonicalType:
+    @pytest.mark.parametrize(
+        ("a", "b"),
+        [
+            ("string", "VARCHAR"),
+            ("long", "BIGINT"),
+            ("int", "INTEGER"),
+            ("double", "DOUBLE"),
+            ("bool", "BOOLEAN"),
+            ("DateTime", "TIMESTAMP"),
+            ("DateTime", "TIMESTAMP WITH TIME ZONE"),
+            ("decimal", "DECIMAL(18,2)"),
+        ],
+    )
+    def test_scope_and_duckdb_spellings_match(self, a, b):
+        assert canonical_type(a) == canonical_type(b) is not None
+
+    def test_nullable_suffix_stripped(self):
+        assert canonical_type("long?") == canonical_type("long") == "INT64"
+
+    def test_distinct_widths_differ(self):
+        assert canonical_type("int") != canonical_type("long")
+
+    def test_unknown_returns_none(self):
+        assert canonical_type("mysterytype") is None
+        assert canonical_type("") is None
+        assert canonical_type(None) is None
+
+
+# -- diff_schema_for_evolution --------------------------------------------
+
+_EVOLVE_DBT_COLS = [
+    {"name": "a", "type": "string"},
+    {"name": "b", "type": "long"},
+    {"name": "event_year_date", "type": "string"},
+]
+
+
+class TestDiffSchemaForEvolution:
+    DBT_COLS = _EVOLVE_DBT_COLS
+
+    def test_new_column_returned_to_add(self):
+        existing = {"a": "VARCHAR", "event_year_date": "VARCHAR"}
+        to_add = diff_schema_for_evolution(
+            self.DBT_COLS, existing, partition_columns=("event_year_date",)
+        )
+        assert [c["name"] for c in to_add] == ["b"]
+
+    def test_exact_match_returns_empty(self):
+        existing = {"a": "VARCHAR", "b": "BIGINT", "event_year_date": "VARCHAR"}
+        assert diff_schema_for_evolution(self.DBT_COLS, existing) == []
+
+    def test_case_insensitive_name_match(self):
+        existing = {"A": "VARCHAR", "B": "BIGINT", "EVENT_YEAR_DATE": "VARCHAR"}
+        assert diff_schema_for_evolution(self.DBT_COLS, existing) == []
+
+    def test_missing_in_dbt_raises(self):
+        existing = {"a": "VARCHAR", "b": "BIGINT", "ghost": "VARCHAR"}
+        with pytest.raises(DbtRuntimeError, match="MISSING from the model"):
+            diff_schema_for_evolution(self.DBT_COLS, existing)
+
+    def test_type_mismatch_raises(self):
+        existing = {"a": "VARCHAR", "b": "VARCHAR"}  # b should be BIGINT
+        with pytest.raises(DbtRuntimeError, match="type changed"):
+            diff_schema_for_evolution(self.DBT_COLS, existing)
+
+    def test_partition_column_absent_from_scan_is_ignored(self):
+        # DuckDB may omit the partition column — it must not be treated as missing or to-add.
+        existing = {"a": "VARCHAR", "b": "BIGINT"}
+        assert (
+            diff_schema_for_evolution(
+                self.DBT_COLS, existing, partition_columns=("event_year_date",)
+            )
+            == []
+        )
+
+    def test_error_message_includes_both_schemas(self):
+        existing = {"a": "VARCHAR", "b": "BIGINT", "ghost": "VARCHAR"}
+        with pytest.raises(DbtRuntimeError) as exc:
+            diff_schema_for_evolution(self.DBT_COLS, existing, location="abfss://x")
+        msg = str(exc.value)
+        assert "Model delta_table_columns:" in msg
+        assert "Existing Delta table schema:" in msg
+        assert "abfss://x" in msg
+
+    def test_unknown_types_do_not_trigger_mismatch(self):
+        # An unmappable type on either side must stay lenient (no spurious failure).
+        existing = {"a": "SOME_EXOTIC_TYPE", "b": "BIGINT", "event_year_date": "VARCHAR"}
+        assert diff_schema_for_evolution(self.DBT_COLS, existing) == []

--- a/tests/unit/test_imds_relay_router.py
+++ b/tests/unit/test_imds_relay_router.py
@@ -1,0 +1,88 @@
+"""Unit tests for the CI IMDS relay router's token cache + helpers.
+
+The router lives at ``.github/scripts/imds_relay_router.py`` (CI infra, not a
+package), so it is loaded by path. Importing is side-effect free — the server
+only starts under ``if __name__ == "__main__"``.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+_ROUTER_PATH = Path(__file__).resolve().parents[2] / ".github" / "scripts" / "imds_relay_router.py"
+
+
+def _load_router():
+    spec = importlib.util.spec_from_file_location("imds_relay_router", _ROUTER_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+router = _load_router()
+
+
+class TestParseExpiresOn:
+    def test_parses_int_string(self):
+        assert router._parse_expires_on("1700000000") == 1700000000
+
+    def test_parses_int(self):
+        assert router._parse_expires_on(1700000000) == 1700000000
+
+    def test_returns_none_for_garbage(self):
+        assert router._parse_expires_on("not-a-number") is None
+        assert router._parse_expires_on(None) is None
+        assert router._parse_expires_on("") is None
+
+
+class TestTokenCache:
+    def _cache(self, skew=300, start=1_000):
+        clock = {"t": start}
+        cache = router.TokenCache(skew_sec=skew, now=lambda: clock["t"])
+        return cache, clock
+
+    def test_miss_returns_none(self):
+        cache, _ = self._cache()
+        assert cache.get("storage") is None
+
+    def test_hit_when_fresh(self):
+        cache, clock = self._cache(skew=300)
+        cache.set("storage", {"access_token": "tok", "expires_on": clock["t"] + 3600})
+        hit = cache.get("storage")
+        assert hit is not None
+        assert hit["access_token"] == "tok"
+
+    def test_stale_within_skew_is_evicted(self):
+        cache, clock = self._cache(skew=300)
+        # Expires in 200s, which is inside the 300s skew → treated as stale.
+        cache.set("storage", {"access_token": "tok", "expires_on": clock["t"] + 200})
+        assert cache.get("storage") is None
+        # Eviction is persistent (entry removed, not just hidden).
+        assert cache.get("storage") is None
+
+    def test_expired_is_evicted(self):
+        cache, clock = self._cache(skew=300)
+        cache.set("storage", {"access_token": "tok", "expires_on": clock["t"] + 3600})
+        assert cache.get("storage") is not None
+        clock["t"] += 3600  # now past expiry
+        assert cache.get("storage") is None
+
+    def test_keys_are_isolated(self):
+        cache, clock = self._cache()
+        cache.set("storage", {"access_token": "s", "expires_on": clock["t"] + 3600})
+        cache.set("datalake", {"access_token": "d", "expires_on": clock["t"] + 3600})
+        assert cache.get("storage")["access_token"] == "s"
+        assert cache.get("datalake")["access_token"] == "d"
+
+    @pytest.mark.parametrize(
+        ("expires_in", "skew", "fresh"),
+        [(3600, 300, True), (301, 300, True), (300, 300, False), (0, 300, False)],
+    )
+    def test_is_fresh_boundary(self, expires_in, skew, fresh):
+        cache, clock = self._cache(skew=skew)
+        entry = {"access_token": "t", "expires_on": clock["t"] + expires_in}
+        assert cache.is_fresh(entry) is fresh

--- a/tests/unit/test_job_lifecycle.py
+++ b/tests/unit/test_job_lifecycle.py
@@ -9,12 +9,14 @@ from urllib.parse import quote as url_quote
 
 import pytest
 import requests.exceptions
+from dbt_common.exceptions import DbtDatabaseError
 
 from dbt.adapters.scope.connections import (
     _UUID_NAMESPACE,
     ScopeConnectionHandle,
     ScopeConnectionManager,
 )
+from dbt.adapters.scope.message_retry import MessageRetryPolicy
 
 # A minimal non-comment SCOPE script that won't be skipped by execute()
 _DUMMY_SCRIPT = '// SCOPE script\nSET @@FeaturePreviews = "EnableDeltaTableDynamicInsert:on";'
@@ -411,6 +413,7 @@ class TestExecuteOrphanCancellation:
         handle._next_job_priority = None
         handle._next_job_timeout_seconds = None
         handle._next_job_model_name = None
+        handle._job_retry_policy = MessageRetryPolicy.disabled()
         handle.submit_and_wait = MagicMock()
         handle.submit_and_wait.return_value = MagicMock(job_id="test-id", result="Succeeded")
         handle.cancel_orphaned_jobs = MagicMock(return_value=[])
@@ -492,6 +495,92 @@ class TestNextJobModelNameOnHandle:
         handle = _make_handle()
         handle._next_job_model_name = "my_model"
         assert handle._next_job_model_name == "my_model"
+
+
+_VERTEX_TIMEOUT_FAILURE = (
+    "SCOPE job 'm_incremental_batch_1_of_1_files_6' (5838e41a) failed: "
+    "Exception in VertexManager, vertex:vertex_1 [SV16_Process],"
+    "GrapheneJniException: Failed to open stream dms://x/y_0_0 with error Operation timed out"
+)
+_FATAL_FAILURE = "SCOPE job 'm' (abc) failed: E_USER_ERROR: syntax error near 'SELECT'"
+
+
+class TestExecuteJobRetry:
+    """execute() re-submits a job on a transient regex-matched failure (#39/#40)."""
+
+    def _manager(self, submit_side_effect):
+        from dbt.adapters.scope.message_retry import MessageRetryPolicy
+
+        mgr = MagicMock(spec=ScopeConnectionManager)
+        mgr.execute = ScopeConnectionManager.execute.__get__(mgr, ScopeConnectionManager)
+
+        @contextmanager
+        def _exception_handler(sql):
+            try:
+                yield
+            except Exception as exc:
+                if isinstance(exc, DbtDatabaseError):
+                    raise
+                raise DbtDatabaseError(str(exc)) from exc
+
+        mgr.exception_handler = _exception_handler
+
+        handle = MagicMock()
+        for attr in (
+            "_next_job_name",
+            "_next_job_au",
+            "_next_job_priority",
+            "_next_job_timeout_seconds",
+            "_next_job_model_name",
+        ):
+            setattr(handle, attr, None)
+
+        handle._job_retry_policy = MessageRetryPolicy.for_job_retry(
+            MagicMock(
+                enable_job_retry=True,
+                job_retry_on_messages=[],
+                job_retry_max_attempts=3,
+                job_retry_initial_wait_seconds=0.01,
+                job_retry_max_wait_seconds=0.01,
+            )
+        )
+        handle.submit_and_wait = MagicMock(side_effect=submit_side_effect)
+        handle.cancel_orphaned_jobs = MagicMock(return_value=[])
+
+        connection = MagicMock()
+        connection.handle = handle
+        connection.credentials = MagicMock(
+            au=100, priority=1, poll_interval_seconds=5, job_timeout_seconds=60
+        )
+        mgr.get_thread_connection.return_value = connection
+        return mgr, handle
+
+    def test_resubmits_on_transient_failure_then_succeeds(self):
+        ok = MagicMock(job_id="job-2", result="Succeeded")
+        mgr, handle = self._manager(
+            submit_side_effect=[DbtDatabaseError(_VERTEX_TIMEOUT_FAILURE), ok]
+        )
+        with patch("dbt.adapters.scope.message_retry.time.sleep"):
+            resp, _ = mgr.execute(_DUMMY_SCRIPT)
+        assert handle.submit_and_wait.call_count == 2
+        assert "job-2" in resp._message
+
+    def test_does_not_retry_fatal_failure(self):
+        mgr, handle = self._manager(submit_side_effect=DbtDatabaseError(_FATAL_FAILURE))
+        with pytest.raises(DbtDatabaseError, match="E_USER_ERROR"):
+            mgr.execute(_DUMMY_SCRIPT)
+        assert handle.submit_and_wait.call_count == 1
+
+    def test_orphan_cancel_runs_once_despite_retries(self):
+        ok = MagicMock(job_id="job-2", result="Succeeded")
+        mgr, handle = self._manager(
+            submit_side_effect=[DbtDatabaseError(_VERTEX_TIMEOUT_FAILURE), ok]
+        )
+        handle._next_job_model_name = "events_daily"
+        with patch("dbt.adapters.scope.message_retry.time.sleep"):
+            mgr.execute(_DUMMY_SCRIPT)
+        handle.cancel_orphaned_jobs.assert_called_once_with("events_daily")
+        assert handle.submit_and_wait.call_count == 2
 
 
 # =====================================================================

--- a/tests/unit/test_job_naming.py
+++ b/tests/unit/test_job_naming.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from dbt.adapters.scope.connections import ScopeConnectionHandle, ScopeConnectionManager
+from dbt.adapters.scope.message_retry import MessageRetryPolicy
 
 # A minimal non-comment SCOPE script that won't be skipped by execute()
 _DUMMY_SCRIPT = '// SCOPE script\nSET @@FeaturePreviews = "EnableDeltaTableDynamicInsert:on";'
@@ -53,6 +54,7 @@ class TestExecuteJobName:
 
         handle = MagicMock()
         handle._next_job_name = None
+        handle._job_retry_policy = MessageRetryPolicy.disabled()
         handle.submit_and_wait = MagicMock()
         handle.submit_and_wait.return_value = MagicMock(job_id="test-id", result="Succeeded")
 
@@ -142,6 +144,7 @@ class TestExecuteMaxWaitOverride:
         handle = MagicMock()
         handle._next_job_name = None
         handle._next_job_timeout_seconds = None
+        handle._job_retry_policy = MessageRetryPolicy.disabled()
         handle.submit_and_wait = MagicMock()
         handle.submit_and_wait.return_value = MagicMock(job_id="test-id", result="Succeeded")
 

--- a/tests/unit/test_message_retry.py
+++ b/tests/unit/test_message_retry.py
@@ -8,7 +8,9 @@ import pytest
 from dbt_common.exceptions import DbtDatabaseError
 
 from dbt.adapters.scope.message_retry import (
+    DEFAULT_JOB_RETRY_RULES,
     MessageRetryPolicy,
+    RetryRule,
     retry_on_message,
 )
 
@@ -258,3 +260,127 @@ class TestRetryOnMessage:
             retry_on_message(op, policy=policy, label="test", sleep=sleeps.append)
         assert calls["n"] == 1
         assert sleeps == []
+
+
+_VERTEX_TIMEOUT_MSG = (
+    "SCOPE job 'm_incremental_batch_1_of_1_files_6' (5838e41a) failed: "
+    "Exception in VertexManager, vertex:vertex_1782102387750_7438_1_16 [SV16_Process],"
+    "com.microsoft.scopeam.store.cosmos.GrapheneJniException: Failed to open stream "
+    "dms://Scopeonbbc-prod/~vm-96533376/2107c3fc_0_0 with error Operation timed out"
+)
+_CANCELLED_MSG = (
+    "SCOPE job 'mon_hue_hue_162bf0_incremental_batch_1_of_1_files_3' (bc09a681) failed: "
+    "Job cancelled by user someSpn-app@SPI through ADL FE"
+)
+_BENIGN_MSG = "SCOPE job 'm' (abc) failed: E_USER_ERROR: syntax error near 'SELECT'"
+
+
+class TestDefaultJobRetryRules:
+    def test_rules_are_retry_rule_instances(self):
+        assert DEFAULT_JOB_RETRY_RULES
+        assert all(isinstance(r, RetryRule) for r in DEFAULT_JOB_RETRY_RULES)
+
+    def test_rule_names_unique(self):
+        names = [r.name for r in DEFAULT_JOB_RETRY_RULES]
+        assert len(names) == len(set(names))
+
+    def test_every_rule_pattern_compiles(self):
+        for rule in DEFAULT_JOB_RETRY_RULES:
+            re.compile(rule.pattern)
+
+    def test_seed_rules_present(self):
+        names = {r.name for r in DEFAULT_JOB_RETRY_RULES}
+        assert "vertex_stream_open_timeout" in names
+        assert "job_cancelled_by_user" in names
+
+
+class _JobCreds:
+    """Duck-typed stand-in for the job-retry slice of ScopeCredentials."""
+
+    def __init__(
+        self,
+        enable_job_retry=True,
+        job_retry_on_messages=None,
+        job_retry_max_attempts=3,
+        job_retry_initial_wait_seconds=30.0,
+        job_retry_max_wait_seconds=300.0,
+    ):
+        self.enable_job_retry = enable_job_retry
+        self.job_retry_on_messages = job_retry_on_messages
+        self.job_retry_max_attempts = job_retry_max_attempts
+        self.job_retry_initial_wait_seconds = job_retry_initial_wait_seconds
+        self.job_retry_max_wait_seconds = job_retry_max_wait_seconds
+
+
+class TestForJobRetry:
+    def test_builtin_rules_match_known_failures(self):
+        policy = MessageRetryPolicy.for_job_retry(_JobCreds())
+        assert policy.enabled
+        assert policy.matches(DbtDatabaseError(_VERTEX_TIMEOUT_MSG)) is not None
+        assert policy.matches(DbtDatabaseError(_CANCELLED_MSG)) is not None
+
+    def test_benign_failure_not_matched(self):
+        policy = MessageRetryPolicy.for_job_retry(_JobCreds())
+        assert policy.matches(DbtDatabaseError(_BENIGN_MSG)) is None
+
+    def test_attempts_map_to_max_retries(self):
+        policy = MessageRetryPolicy.for_job_retry(_JobCreds(job_retry_max_attempts=3))
+        assert policy.max_retries == 2
+
+    def test_disabled_flag_produces_disabled_policy(self):
+        policy = MessageRetryPolicy.for_job_retry(_JobCreds(enable_job_retry=False))
+        assert not policy.enabled
+        assert policy.matches(DbtDatabaseError(_VERTEX_TIMEOUT_MSG)) is None
+
+    def test_user_patterns_merged_with_builtins(self):
+        policy = MessageRetryPolicy.for_job_retry(
+            _JobCreds(job_retry_on_messages=["re:E_TRANSIENT_\\d+", "Flaky substring"])
+        )
+        assert policy.matches(DbtDatabaseError("boom E_TRANSIENT_42")) is not None
+        assert policy.matches(DbtDatabaseError("a Flaky substring here")) is not None
+        assert policy.matches(DbtDatabaseError(_VERTEX_TIMEOUT_MSG)) is not None
+
+    def test_backoff_defaults_are_job_scaled(self):
+        policy = MessageRetryPolicy.for_job_retry(_JobCreds())
+        assert policy.initial_wait_seconds == 30.0
+        assert policy.max_wait_seconds == 300.0
+
+    def test_rejects_zero_attempts(self):
+        with pytest.raises(ValueError, match="job_retry_max_attempts must be >= 1"):
+            MessageRetryPolicy.for_job_retry(_JobCreds(job_retry_max_attempts=0))
+
+    def test_rejects_initial_greater_than_max(self):
+        with pytest.raises(ValueError, match="must be <="):
+            MessageRetryPolicy.for_job_retry(
+                _JobCreds(job_retry_initial_wait_seconds=500, job_retry_max_wait_seconds=10)
+            )
+
+    def test_rejects_empty_user_pattern(self):
+        with pytest.raises(ValueError, match="non-empty strings"):
+            MessageRetryPolicy.for_job_retry(_JobCreds(job_retry_on_messages=[""]))
+
+    def test_resubmit_on_match_then_succeed(self):
+        policy = MessageRetryPolicy.for_job_retry(_JobCreds())
+        calls = {"n": 0}
+
+        def op():
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise DbtDatabaseError(_VERTEX_TIMEOUT_MSG)
+            return "ok"
+
+        result = retry_on_message(op, policy=policy, label="job", sleep=lambda _s: None)
+        assert result == "ok"
+        assert calls["n"] == 2
+
+    def test_no_retry_on_benign_failure(self):
+        policy = MessageRetryPolicy.for_job_retry(_JobCreds())
+        calls = {"n": 0}
+
+        def op():
+            calls["n"] += 1
+            raise DbtDatabaseError(_BENIGN_MSG)
+
+        with pytest.raises(DbtDatabaseError):
+            retry_on_message(op, policy=policy, label="job", sleep=lambda _s: None)
+        assert calls["n"] == 1

--- a/tests/unit/test_quota_eviction.py
+++ b/tests/unit/test_quota_eviction.py
@@ -11,6 +11,7 @@ import pytest
 from dbt.adapters.scope.quota_eviction import (
     _EVICTION_LOCKS,
     QuotaEvictionPolicy,
+    _gather_and_cancel,
     _lock_for,
     is_quota_error,
     retry_with_quota_eviction,
@@ -43,6 +44,7 @@ class _FakeCtx:
         self.list_calls: list[tuple[str | None, int]] = []
         self.cancel_calls: list[str] = []
         self.cancel_failures: dict[str, Exception] = {}
+        self.self_job_ids: set[str] = set()
 
     def list_jobs(self, filter_expr: str | None = None, top: int = 100) -> list[dict[str, Any]]:
         self.list_calls.append((filter_expr, top))
@@ -52,6 +54,9 @@ class _FakeCtx:
         self.cancel_calls.append(job_id)
         if job_id in self.cancel_failures:
             raise self.cancel_failures[job_id]
+
+    def is_self_job(self, job: dict[str, Any]) -> bool:
+        return str(job.get("jobId") or "") in self.self_job_ids
 
 
 class TestQuotaEvictionPolicyConstruction:
@@ -160,6 +165,54 @@ class TestSelectVictims:
         ]
         victims = select_victims(jobs, k=2)
         assert victims[0]["jobId"] == "j2"
+
+
+class TestSelfJobExclusion:
+    """_gather_and_cancel must never evict jobs owned by the current run (#39)."""
+
+    def _policy(self, cancel_num: int = 5) -> QuotaEvictionPolicy:
+        return QuotaEvictionPolicy(
+            account="acct",
+            enabled=True,
+            max_attempts=5,
+            cancel_num=cancel_num,
+            wait_seconds=1.0,
+            jitter_seconds=0.0,
+        )
+
+    def test_self_jobs_excluded_from_victims(self):
+        jobs = [
+            {"jobId": "self1", "priority": 1000, "submitTime": "2020-01-01"},
+            {"jobId": "other1", "priority": 900, "submitTime": "2021-01-01"},
+            {"jobId": "other2", "priority": 800, "submitTime": "2022-01-01"},
+        ]
+        ctx = _FakeCtx(jobs)
+        ctx.self_job_ids = {"self1"}
+        cancelled = _gather_and_cancel(ctx, self._policy())
+        assert "self1" not in ctx.cancel_calls
+        assert ctx.cancel_calls == ["other1", "other2"]
+        assert [c["jobId"] for c in cancelled] == ["other1", "other2"]
+
+    def test_all_self_jobs_yields_no_victims(self):
+        jobs = [
+            {"jobId": "self1", "priority": 1000, "submitTime": "2020-01-01"},
+            {"jobId": "self2", "priority": 900, "submitTime": "2021-01-01"},
+        ]
+        ctx = _FakeCtx(jobs)
+        ctx.self_job_ids = {"self1", "self2"}
+        cancelled = _gather_and_cancel(ctx, self._policy())
+        assert ctx.cancel_calls == []
+        assert cancelled == []
+
+    def test_no_self_jobs_cancels_normally(self):
+        jobs = [
+            {"jobId": "a", "priority": 5, "submitTime": "2020-01-01"},
+            {"jobId": "b", "priority": 3, "submitTime": "2021-01-01"},
+        ]
+        ctx = _FakeCtx(jobs)
+        cancelled = _gather_and_cancel(ctx, self._policy())
+        assert ctx.cancel_calls == ["a", "b"]
+        assert len(cancelled) == 2
 
 
 class TestLockFor:

--- a/tests/unit/test_script_builder.py
+++ b/tests/unit/test_script_builder.py
@@ -629,18 +629,18 @@ class TestExtractColumnsSeparation:
 
 
 class TestInsertColumnList:
-    """Tests that INSERT INTO uses explicit SELECT column list to prevent positional mismatch."""
+    """INSERT uses a named-column list."""
 
     def test_insert_includes_column_names(self, sample_config):
-        """SELECT should list all delta column names explicitly in table order."""
+        """INSERT names the target columns and the SELECT lists them in the same order."""
         script = ScriptBuilder.build_full_refresh(sample_config, "SELECT * FROM @data")
-        assert "INSERT INTO @target" in script
+        assert "INSERT INTO @target (col_str, col_long, col_dt, event_year_date)" in script
         assert "SELECT col_str, col_long, col_dt, event_year_date FROM @batch_data;" in script
 
     def test_insert_column_order_matches_delta_columns(self, sample_config):
-        """Column list in SELECT must match delta_columns order."""
+        """Named column list and SELECT list both follow delta_columns order."""
         script = ScriptBuilder.build_incremental(sample_config, "SELECT * FROM @data")
-        assert "INSERT INTO @target" in script
+        assert "INSERT INTO @target (col_str, col_long, col_dt, event_year_date)" in script
         assert "SELECT col_str, col_long, col_dt, event_year_date FROM @batch_data;" in script
 
     def test_mismatched_select_order_still_correct_insert(self):
@@ -675,7 +675,10 @@ class TestInsertColumnList:
             "FROM @data"
         )
         script = ScriptBuilder.build_incremental(config, model_sql)
-        # SELECT should reorder columns to match table definition order
+        assert (
+            "INSERT INTO @target (cluster_region_zone, azure_resource_id,"
+            " original_event_timestamp, query_count, event_year_date)"
+        ) in script
         expected = (
             "SELECT cluster_region_zone, azure_resource_id,"
             " original_event_timestamp, query_count, event_year_date"


### PR DESCRIPTION
## Summary

This PR delivers three related features for the SCOPE adapter. All logic is unit-tested and the full integration suite passes locally (`-n 32`, GREEN).

### 1. Delta Lake schema evolution — Closes #35
Before building each SCOPE script, the adapter diffs the model's `delta_table_columns` against the live Delta table schema (read with DuckDB, after confirming `_delta_log` exists on ADLS):
- **New column** → injects `ALTER TABLE @target ADD COLUMN IF NOT EXISTS <name> <type>;` so the table evolves before the `INSERT`.
- **Column removed** from the model (still in the table) → fails with a `DbtRuntimeError` showing both schemas.
- **Column type changed** → fails with a diff (equivalence-based, e.g. SCOPE `long` ≡ Delta `BIGINT`).
- **No `_delta_log`** (new table) → no-op; `CREATE TABLE` creates the full schema.

Applies to both `incremental` and `table` (full-refresh) materializations. No new dependency (reuses the existing DuckDB + ADLS introspection).

### 2. Avoid self-cancel in quota eviction — Closes #39
The quota-eviction layer now excludes the current dbt run's own jobs from victim selection via `is_self_job(job)` — true if the job is in the process `_active_jobs` registry **or** its `related.runId == _run_id`. So eviction never cancels our own in-flight work.

### 3. Retry transient SCOPE job failures via a RegEx rule set — Closes #40
A curated, growable `RetryRule(name, pattern, description)` data structure (`DEFAULT_JOB_RETRY_RULES` in `message_retry.py`), seeded conservatively with:
- `Exception in VertexManager ... Failed to open stream ... Operation timed out`
- `Job cancelled by user ...` (external/cross-pipeline cancels — the #39 fallback)

`MessageRetryPolicy.for_job_retry()` merges built-ins with user-configured `job_retry_on_messages`; `execute()` wraps `submit_and_wait` so a matching job failure **re-submits a fresh job** with capped exponential backoff. Non-matching failures propagate unchanged. To grow coverage later, append a `RetryRule`.

**New profile config:** `enable_job_retry`, `job_retry_on_messages`, `job_retry_max_attempts`, `job_retry_initial_wait_seconds`, `job_retry_max_wait_seconds` (all validated).

## Testing
- `ruff check` + `ruff format --check`: clean
- Unit: **547 passed** (schema-evolution diff/canonicalizer/introspection; eviction self-exclusion; rule matching; `for_job_retry`; credentials validation; `execute()` re-submit-on-match / no-retry-on-fatal)
- Integration (full suite, `-n 32`): **4 passed** — including a new `TestSchemaEvolution` (datagen v1 → datagen v2 → assert `region_name` evolved in and populated), and `TestIncremental` (re-runs guard against type-check false positives)

Closes #35
Closes #39
Closes #40
